### PR TITLE
BungeeCord support

### DIFF
--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/data/HandshakeData.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/data/HandshakeData.kt
@@ -11,7 +11,7 @@ import java.net.InetAddress
  */
 data class HandshakeData(
     val protocol: Int,
-    val address: InetAddress,
+    val address: String,
     val port: UShort,
     val nextState: PacketState
 )

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/HandshakeHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/HandshakeHandler.kt
@@ -2,14 +2,19 @@ package org.kryptonmc.krypton.packet.handlers
 
 import net.kyori.adventure.extra.kotlin.text
 import net.kyori.adventure.extra.kotlin.translatable
+import net.kyori.adventure.text.Component.text
 import org.kryptonmc.krypton.KryptonServer
 import org.kryptonmc.krypton.ServerInfo
 import org.kryptonmc.krypton.ServerStorage
 import org.kryptonmc.krypton.api.event.events.handshake.HandshakeEvent
 import org.kryptonmc.krypton.packet.Packet
+import org.kryptonmc.krypton.packet.`in`.handshake.BungeeCordHandshakeData
 import org.kryptonmc.krypton.packet.`in`.handshake.PacketInHandshake
+import org.kryptonmc.krypton.packet.`in`.handshake.splitData
+import org.kryptonmc.krypton.packet.out.login.PacketOutLoginDisconnect
 import org.kryptonmc.krypton.packet.session.Session
 import org.kryptonmc.krypton.packet.state.PacketState
+import org.kryptonmc.krypton.util.logger
 import java.net.InetSocketAddress
 
 /**
@@ -26,17 +31,38 @@ class HandshakeHandler(
         if (packet !is PacketInHandshake) return // ignore if not a handshake packet
         server.eventBus.call(HandshakeEvent(session.channel.remoteAddress() as InetSocketAddress))
 
-        when (val nextState = packet.data.nextState) {
-            PacketState.LOGIN -> handleLogin(packet)
-            PacketState.STATUS -> handleStatus()
-            else -> throw UnsupportedOperationException("Invalid next state $nextState")
+        if (packet.data.address.split('\u0000').size > 1 && !server.config.server.bungeecord) {
+            session.sendPacket(PacketOutLoginDisconnect(text("Please notify the server administrator that they are attempting to use BungeeCord IP forwarding without enabling BungeeCord support in their configuration file.")))
+            session.disconnect(text(""))
+            return
         }
+
+        if (server.config.server.bungeecord) {
+            val data = try {
+                packet.data.address.splitData()
+            } catch (exception: Exception) {
+                session.disconnect(text("Could not decode BungeeCord handshake data! Please report this to an administrator!"))
+                LOGGER.debug("Error decoding BungeeCord handshake data! Please report this to Krypton.", exception)
+                return
+            }
+
+            LOGGER.debug("Detected BungeeCord login for ${data.uuid}")
+            changeState(packet, packet.data.nextState, data)
+        }
+
+        changeState(packet, packet.data.nextState)
+    }
+
+    private fun changeState(packet: PacketInHandshake, state: PacketState, data: BungeeCordHandshakeData? = null) = when (state) {
+        PacketState.LOGIN -> handleLogin(packet, data)
+        PacketState.STATUS -> handleStatus()
+        else -> throw UnsupportedOperationException("Invalid next state $state!")
     }
 
     /**
      * Handles when next state is [PacketState.LOGIN]
      */
-    private fun handleLogin(packet: PacketInHandshake) {
+    private fun handleLogin(packet: PacketInHandshake, data: BungeeCordHandshakeData? = null) {
         session.currentState = PacketState.LOGIN
         if (packet.data.protocol != ServerInfo.PROTOCOL) {
             val key = when {
@@ -55,7 +81,7 @@ class HandshakeHandler(
             session.disconnect(translatable { key("multiplayer.disconnect.server_full") })
             return
         }
-        session.handler = LoginHandler(server, server.sessionManager, session)
+        session.handler = LoginHandler(server, server.sessionManager, session, data)
     }
 
     /**
@@ -64,5 +90,10 @@ class HandshakeHandler(
     private fun handleStatus() {
         session.currentState = PacketState.STATUS
         session.handler = StatusHandler(server, session)
+    }
+
+    companion object {
+
+        private val LOGGER = logger<HandshakeHandler>()
     }
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/handshake/PacketInHandshake.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/handshake/PacketInHandshake.kt
@@ -1,13 +1,16 @@
 package org.kryptonmc.krypton.packet.`in`.handshake
 
 import io.netty.buffer.ByteBuf
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.kryptonmc.krypton.auth.ProfileProperty
 import org.kryptonmc.krypton.packet.Packet
 import org.kryptonmc.krypton.packet.PacketInfo
 import org.kryptonmc.krypton.packet.data.HandshakeData
 import org.kryptonmc.krypton.packet.state.PacketState
 import org.kryptonmc.krypton.util.readString
 import org.kryptonmc.krypton.util.readVarInt
-import org.kryptonmc.krypton.util.toInetAddress
+import java.util.UUID
 
 /**
  * This is the only packet in the [Handshake][PacketState.HANDSHAKE] state.
@@ -26,10 +29,28 @@ class PacketInHandshake : Packet {
 
     override fun read(buf: ByteBuf) {
         val protocol = buf.readVarInt()
-        val address = buf.readString(255).toInetAddress()
+        val address = buf.readString()
         val port = buf.readUnsignedShort().toUShort()
         val nextState = PacketState.fromId(buf.readVarInt())
 
         data = HandshakeData(protocol, address, port, nextState)
     }
+}
+
+data class BungeeCordHandshakeData(
+    val originalIp: String,
+    val forwardedIp: String,
+    val uuid: UUID,
+    val properties: List<ProfileProperty>
+)
+
+fun String.splitData(): BungeeCordHandshakeData {
+    val split = split('\u0000')
+    require(split.size > 2) { "String does not contain at least the proxy, forwarded IP address and UUID" }
+    return BungeeCordHandshakeData(
+        split[0],
+        split[1],
+        UUID.fromString(split[2].replaceFirst("(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})".toRegex(), "$1-$2-$3-$4-$5")),
+        if (split.size > 3) Json.decodeFromString(split[3]) else emptyList()
+    )
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/KryptonConfig.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/KryptonConfig.kt
@@ -41,7 +41,8 @@ data class ServerConfig(
     val port: Int = 25565,
     @SerialName("online-mode") val onlineMode: Boolean = true,
     @SerialName("compression-threshold") val compressionThreshold: Int = 256,
-    @SerialName("tick-threshold") val tickThreshold: Int = 60000
+    @SerialName("tick-threshold") val tickThreshold: Int = 60000,
+    val bungeecord: Boolean = false
 )
 
 /**

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/utils.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/utils.kt
@@ -3,6 +3,7 @@ package org.kryptonmc.krypton.util
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.kryptonmc.krypton.api.world.Gamemode
+import org.kryptonmc.krypton.auth.GameProfile
 import java.net.InetAddress
 import kotlin.math.log2
 import kotlin.math.max

--- a/server/src/main/resources/config.conf
+++ b/server/src/main/resources/config.conf
@@ -6,6 +6,7 @@ server {
   online-mode = true # Whether the server is in online mode (authenticates users through Mojang)
   compression-threshold = 256 # The threshold at which packets larger will be compressed (-1 to disable)
   tick-threshold = 60000 # The time that the server must be non responsive for before watchdog considers it dead
+  bungeecord = false
 }
 
 status {


### PR DESCRIPTION
Not sure why I chose to add this rather than adding something else, but I did, so now it's here. This adds support for BungeeCord's IP forwarding mechanism, and rremoves both the string read limit for the handshake address and the assumption that the address can always be converted to an `InetAddress` (which isn't always true when it's a null-separated string, like what we have with BungeeCord).