### PR TITLE
Watchdog improvements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = "org.kryptonmc"
-version = "0.18.6"
+version = "0.18.7"
 
 rootProject.extra["globalVersion"] = project.version
 

--- a/server/src/main/kotlin/org/kryptonmc/krypton/KryptonServer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/KryptonServer.kt
@@ -148,6 +148,7 @@ class KryptonServer(private val disableGUI: Boolean) : Server {
         if (config.advanced.enableJmxMonitoring) KryptonStatistics.register(this)
 
         if (config.other.timeoutTime > 0) {
+            LOGGER.debug("Starting watchdog")
             watchdog = WatchdogProcess(this)
             watchdog?.start()
         }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/Metrics.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/Metrics.kt
@@ -77,7 +77,7 @@ internal object KryptonMetrics {
         metrics += DrilldownPie("java_version") {
             val javaVersion = System.getProperty("java.version")
             val major = javaVersion.split("\\.")[0]
-            val dot = javaVersion.indexOf('.')
+            val dot = javaVersion.lastIndexOf('.')
 
             val release = "Java " + if (major == "1") {
                 javaVersion.substring(0, dot)

--- a/server/src/main/kotlin/org/kryptonmc/krypton/NettyProcess.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/NettyProcess.kt
@@ -72,9 +72,13 @@ class NettyProcess(private val server: KryptonServer) {
             LOGGER.error("-------------------------------------------------")
             exitProcess(0)
         } finally {
-            workerGroup.shutdownGracefully()
-            bossGroup.shutdownGracefully()
+            shutdown()
         }
+    }
+
+    fun shutdown() {
+        workerGroup.shutdownGracefully()
+        bossGroup.shutdownGracefully()
     }
 
     // Determines the best loop group to use based on what is available on the current operating system

--- a/server/src/main/kotlin/org/kryptonmc/krypton/NettyProcess.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/NettyProcess.kt
@@ -70,7 +70,7 @@ class NettyProcess(private val server: KryptonServer) {
             LOGGER.error("Exception: $exception")
             LOGGER.error("Perhaps a server is already running on that port?")
             LOGGER.error("-------------------------------------------------")
-            exitProcess(0)
+            server.stop()
         } finally {
             shutdown()
         }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/WatchdogProcess.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/WatchdogProcess.kt
@@ -21,7 +21,6 @@ class WatchdogProcess(private val server: KryptonServer) : Thread("Krypton Watch
     }
 
     private val timeoutTime = server.config.other.timeoutTime * 1000L
-    private val restartOnCrash = server.config.other.restartOnCrash
     private val earlyWarningInterval = min(server.config.other.earlyWarningInterval, timeoutTime)
     private val earlyWarningDelay = min(server.config.other.earlyWarningDelay, timeoutTime)
 
@@ -82,7 +81,9 @@ class WatchdogProcess(private val server: KryptonServer) : Thread("Krypton Watch
             }
             LOGGER.printBar(isLongTimeout)
 
-            if (isLongTimeout && server.isRunning) server.stop(restartOnCrash)
+            if (isLongTimeout && server.isRunning) {
+                if (server.config.other.restartOnCrash) server.restart() else server.stop()
+            }
         }
     }
 

--- a/server/src/main/kotlin/org/kryptonmc/krypton/WatchdogProcess.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/WatchdogProcess.kt
@@ -1,9 +1,12 @@
 package org.kryptonmc.krypton
 
+import org.apache.logging.log4j.Logger
+import org.kryptonmc.krypton.KryptonServer.KryptonServerInfo
 import org.kryptonmc.krypton.util.concurrent.NamedUncaughtExceptionHandler
 import org.kryptonmc.krypton.util.logger
-import java.util.Locale
-import kotlin.system.exitProcess
+import java.lang.management.ManagementFactory
+import java.lang.management.ThreadInfo
+import kotlin.math.min
 
 /**
  * The server watchdog. It's watching you...
@@ -17,21 +20,88 @@ class WatchdogProcess(private val server: KryptonServer) : Thread("Krypton Watch
         isDaemon = true
     }
 
-    private val tickThreshold = server.config.server.tickThreshold
+    private val timeoutTime = server.config.other.timeoutTime * 1000L
+    private val restartOnCrash = server.config.other.restartOnCrash
+    private val earlyWarningInterval = min(server.config.other.earlyWarningInterval, timeoutTime.toLong())
+    private val earlyWarningDelay = min(server.config.other.earlyWarningDelay, timeoutTime.toLong())
+
+    private var lastEarlyWarning = 0L
+    @Volatile private var lastTick = 0L
+    @Volatile private var stopping = false
+
+    fun tick(time: Long) {
+        if (lastTick == 0L) hasStarted = true
+        lastTick = time
+    }
+
+    fun shutdown() {
+        stopping = true
+    }
 
     override fun run() {
-        while (server.isRunning) {
-            val tickTime = System.currentTimeMillis() - server.lastTickTime
-            if (tickTime > tickThreshold) {
-                LOGGER.fatal("A single server tick took ${"%.2f".format(Locale.ROOT, tickTime / 1000.0f)} seconds (threshold: $tickThreshold)!")
-                LOGGER.fatal("Considering it crashed, shutting down...")
-                exitProcess(1)
+        if (DISABLE_WATCHDOG) return // Disable watchdog early if the flag is set
+
+        while (!stopping) {
+            val currentTime = System.currentTimeMillis()
+            if (!(lastTick != 0L && timeoutTime > 0 && hasStarted && (!server.isRunning || (currentTime > lastTick + earlyWarningInterval)))) continue
+            val isLongTimeout = currentTime > lastTick + timeoutTime || (!server.isRunning && currentTime > lastTick + 1000)
+
+            if (!isLongTimeout && (earlyWarningInterval <= 0 || !hasStarted || currentTime < lastEarlyWarning + earlyWarningInterval || currentTime < lastTick + earlyWarningDelay)) continue
+            if (!isLongTimeout && !server.isRunning) continue
+            lastEarlyWarning = currentTime
+
+            if (isLongTimeout) {
+                LOGGER.error("------------------------------")
+                LOGGER.error("The server has stopped responding! This is (probably) not a Krypton issue.")
+                LOGGER.error("If you see a plugin in the Server thread dump below, then please report it to that author")
+                LOGGER.error("\t *Especially* if it looks like HTTP or MySQL operations are occurring")
+                LOGGER.error("If you see a world save or edit, then it means you did far more than your server can handle at once")
+                LOGGER.error("\t If this is the case, consider increasing timeout-time in the main config.conf under \"other\", but note that this will replace the crash with LARGE lag spikes")
+                LOGGER.error("If you are unsure, or still think that this is a Krypton issue, please report this to https://github.com/KryptonMC/Krypton/issues")
+                LOGGER.error("Please ensure you include ALL relevant console errors and thread dumps")
+                LOGGER.error("Krypton version: ${KryptonServerInfo.version} (for Minecraft ${KryptonServerInfo.minecraftVersion})")
+            } else {
+                LOGGER.error("--- DO NOT REPORT THIS TO KRYPTON - THIS IS NOT A BUG OR CRASH - ${KryptonServerInfo.version} (MC ${KryptonServerInfo.minecraftVersion}) ---")
+                LOGGER.error("The server has not responded for ${(currentTime - lastTick) / 1000} seconds! Creating thread dump")
             }
+
+            LOGGER.error("------------------------------")
+            LOGGER.error("Server thread dump (Look for plugins here before reporting this to Krypton!):")
+            THREAD_BEAN.getThreadInfo(server.mainThread.id, Int.MAX_VALUE)?.dump(LOGGER)
+            LOGGER.error("------------------------------")
+
+            if (isLongTimeout) {
+                LOGGER.error("Entire Thread Dump:")
+                THREAD_BEAN.dumpAllThreads(true, true).forEach { it.dump(LOGGER) }
+            } else {
+                LOGGER.error("--- DO NOT REPORT THIS TO KRYPTON - THIS IS NOT A BUG OR CRASH ---")
+            }
+            LOGGER.error("------------------------------")
+
+            if (isLongTimeout && server.isRunning) server.stop(restartOnCrash)
         }
     }
 
     companion object {
 
+        @Volatile var hasStarted = false
+
+        private val DISABLE_WATCHDOG = java.lang.Boolean.getBoolean("disable.watchdog")
+        private val THREAD_BEAN = ManagementFactory.getThreadMXBean()
         private val LOGGER = logger("Watchdog (I'm watching you)")
     }
+}
+
+private fun ThreadInfo.dump(logger: Logger) {
+    logger.error("------------------------------")
+    logger.error("Current Thread: $threadName")
+    logger.error("\tPID: $threadId | Suspended: $isSuspended | Native: $isInNative | State: $threadState")
+
+    if (lockedMonitors.isNotEmpty()) {
+        logger.error("\tThread is waiting on monitor(s):")
+        lockedMonitors.forEach { logger.error("\t\tLocked on: ${it.lockedStackFrame}") }
+    }
+
+    logger.error("\tStack:")
+    stackTrace.forEach { logger.error("\t\t$it") }
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/KryptonCommandManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/KryptonCommandManager.kt
@@ -21,6 +21,7 @@ import org.kryptonmc.krypton.api.command.CommandManager
 import org.kryptonmc.krypton.api.command.Sender
 import org.kryptonmc.krypton.api.event.events.play.PermissionCheckEvent
 import org.kryptonmc.krypton.api.event.events.play.PermissionCheckResult
+import org.kryptonmc.krypton.command.commands.RestartCommand
 import org.kryptonmc.krypton.command.commands.StopCommand
 import java.util.Locale
 import java.util.concurrent.CompletableFuture
@@ -126,7 +127,8 @@ class KryptonCommandManager(private val server: KryptonServer) : CommandManager 
         .build()
 
     internal fun registerBuiltins() {
-        register(StopCommand())
+        register(StopCommand(server))
+        register(RestartCommand(server))
     }
 
     companion object {

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/RestartCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/RestartCommand.kt
@@ -9,6 +9,6 @@ class RestartCommand(private val server: KryptonServer) : Command("restart", "kr
 
     override fun execute(sender: Sender, args: List<String>) {
         sender.sendMessage(Component.text("Attempting to restart the server..."))
-        server.stop(true)
+        server.restart()
     }
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/RestartCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/RestartCommand.kt
@@ -5,13 +5,10 @@ import org.kryptonmc.krypton.KryptonServer
 import org.kryptonmc.krypton.api.command.Command
 import org.kryptonmc.krypton.api.command.Sender
 
-/**
- * Stop the server. That's literally all this does
- */
-class StopCommand(private val server: KryptonServer) : Command("stop", "krypton.command.stop") {
+class RestartCommand(private val server: KryptonServer) : Command("restart", "krypton.command.restart") {
 
     override fun execute(sender: Sender, args: List<String>) {
-        sender.sendMessage(Component.text("Stopping server..."))
-        server.stop()
+        sender.sendMessage(Component.text("Attempting to restart the server..."))
+        server.stop(true)
     }
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/console/KryptonConsole.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/console/KryptonConsole.kt
@@ -4,7 +4,6 @@ import net.minecrell.terminalconsole.SimpleTerminalConsole
 import org.jline.reader.LineReader
 import org.jline.reader.LineReaderBuilder
 import org.kryptonmc.krypton.KryptonServer
-import kotlin.system.exitProcess
 
 /**
  * The console handler for this server
@@ -15,7 +14,7 @@ class KryptonConsole(private val server: KryptonServer) : SimpleTerminalConsole(
 
     override fun runCommand(command: String) = server.commandManager.dispatch(server.console, command)
 
-    override fun shutdown() = exitProcess(0)
+    override fun shutdown() = server.stop()
 
     override fun buildReader(builder: LineReaderBuilder): LineReader = super.buildReader(
         builder.appName("Krypton Console")

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/handshake/PacketInHandshake.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/handshake/PacketInHandshake.kt
@@ -44,9 +44,10 @@ data class BungeeCordHandshakeData(
     val properties: List<ProfileProperty>
 )
 
-fun String.splitData(): BungeeCordHandshakeData {
+fun String.splitData(): BungeeCordHandshakeData? {
     val split = split('\u0000')
-    require(split.size > 2) { "String does not contain at least the proxy, forwarded IP address and UUID" }
+    if (split.size <= 2) return null
+//    require(split.size > 2) { "String does not contain at least the proxy, forwarded IP address and UUID" }
     return BungeeCordHandshakeData(
         split[0],
         split[1],

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/KryptonConfig.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/KryptonConfig.kt
@@ -13,6 +13,7 @@ import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
 import org.kryptonmc.krypton.api.world.Difficulty
 import org.kryptonmc.krypton.api.world.Gamemode
+import org.kryptonmc.krypton.serializers.ComponentSerializer
 
 private val DEFAULT_MOTD = Component.text("Krypton is a Minecraft server written in Kotlin!")
     .color(TextColor.color(128, 0, 255))
@@ -41,9 +42,7 @@ data class ServerConfig(
     val ip: String = "0.0.0.0",
     val port: Int = 25565,
     @SerialName("online-mode") val onlineMode: Boolean = true,
-    @SerialName("compression-threshold") val compressionThreshold: Int = 256,
-    @SerialName("tick-threshold") val tickThreshold: Int = 60000,
-    val bungeecord: Boolean = false
+    @SerialName("compression-threshold") val compressionThreshold: Int = 256
 )
 
 /**
@@ -92,7 +91,14 @@ data class QueryConfig(
  */
 @Serializable
 data class OtherConfig(
-    val metrics: Boolean = true
+    val bungeecord: Boolean = false,
+    val metrics: Boolean = true,
+    @SerialName("timeout-time") val timeoutTime: Int = 60000,
+    @SerialName("restart-on-crash") val restartOnCrash: Boolean = true,
+    @SerialName("restart-script") val restartScript: String = "./start.sh",
+    @SerialName("restart-message") @Serializable(TextComponentSerializer::class) val restartMessage: TextComponent = Component.empty(),
+    @SerialName("early-warning-interval") val earlyWarningInterval: Long = 5000,
+    @SerialName("early-warning-delay") val earlyWarningDelay: Long = 10000
 )
 
 internal object GamemodeSerializer : KSerializer<Gamemode> by Gamemode.serializer() {

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/KryptonConfig.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/KryptonConfig.kt
@@ -93,10 +93,9 @@ data class QueryConfig(
 data class OtherConfig(
     val bungeecord: Boolean = false,
     val metrics: Boolean = true,
-    @SerialName("timeout-time") val timeoutTime: Int = 60000,
+    @SerialName("timeout-time") val timeoutTime: Int = 60,
     @SerialName("restart-on-crash") val restartOnCrash: Boolean = true,
     @SerialName("restart-script") val restartScript: String = "./start.sh",
-    @SerialName("restart-message") @Serializable(TextComponentSerializer::class) val restartMessage: TextComponent = Component.empty(),
     @SerialName("early-warning-interval") val earlyWarningInterval: Long = 5000,
     @SerialName("early-warning-delay") val earlyWarningDelay: Long = 10000
 )

--- a/server/src/main/resources/config.conf
+++ b/server/src/main/resources/config.conf
@@ -5,8 +5,6 @@ server {
   port = 25565 # The port for the server to bind to. Defaults to 25565
   online-mode = true # Whether the server is in online mode (authenticates users through Mojang)
   compression-threshold = 256 # The threshold at which packets larger will be compressed (-1 to disable)
-  tick-threshold = 60000 # The time that the server must be non responsive for before watchdog considers it dead
-  bungeecord = false
 }
 
 status {
@@ -38,5 +36,14 @@ query {
 }
 
 other {
-  metrics = true
+  bungeecord = false
+  metrics = true # Whether we should enable bStats metrics for the server or not
+
+  # Watchdog settings
+  timeout-time = 60 # The time that the server must be non responsive for before watchdog considers it dead
+  restart-on-crash = true # If we should attempt to restart the server if it crashes
+  restart-script = "./start.sh"
+  restart-message = "Server closed."
+  early-warning-interval = 5000
+  early-warning-delay = 10000
 }

--- a/server/src/test/kotlin/org/kryptonmc/krypton/CommandTests.kt
+++ b/server/src/test/kotlin/org/kryptonmc/krypton/CommandTests.kt
@@ -3,13 +3,11 @@ package org.kryptonmc.krypton
 import com.mojang.brigadier.arguments.LongArgumentType
 import com.mojang.brigadier.builder.LiteralArgumentBuilder
 import com.mojang.brigadier.builder.RequiredArgumentBuilder
-import com.mojang.brigadier.exceptions.CommandSyntaxException.BUILT_IN_EXCEPTIONS
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
-import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.format.NamedTextColor
 import org.junit.jupiter.api.BeforeAll
@@ -27,15 +25,15 @@ class CommandTests {
 
     @Test
     fun `stop command actually stops the server`() {
-        val stop = StopCommand()
+        val stop = StopCommand(server)
         val sender = mockk<Sender> {
             every { sendMessage(any()) } just runs
         }
 
-        assertThrows<IllegalStateException> { stop.execute(sender, emptyList()) }
+        stop.execute(sender, emptyList())
         verify { sender.sendMessage(any()) }
         try {
-            verify { exitProcess(any()) }
+            verify { server.stop() }
         } catch (ignored: IllegalStateException) {}
     }
 
@@ -65,6 +63,7 @@ class CommandTests {
 
         private val server = mockk<KryptonServer> {
             every { eventBus } returns eventBusMock
+            every { stop(any()) } returns Unit
         }
 
         private val manager = KryptonCommandManager(server)

--- a/server/src/test/kotlin/org/kryptonmc/krypton/ConfigTests.kt
+++ b/server/src/test/kotlin/org/kryptonmc/krypton/ConfigTests.kt
@@ -26,13 +26,17 @@ class ConfigTests {
         val parsed = ConfigFactory.parseResources("config.conf")
         val config = Hocon.decodeFromConfig<KryptonConfig>(parsed)
 
+        // Server settings
         assertEquals("0.0.0.0", config.server.ip)
         assertEquals(25565, config.server.port)
         assertTrue(config.server.onlineMode)
         assertEquals(256, config.server.compressionThreshold)
-        assertEquals(60000, config.server.tickThreshold)
+
+        // Status settings
         assertEquals(Component.text("Krypton is a Minecraft server written in Kotlin!", TextColor.fromHexString("#8000ff")), config.status.motd)
         assertEquals(20, config.status.maxPlayers)
+
+        // World settings
         assertEquals("world", config.world.name)
         assertEquals(Gamemode.SURVIVAL, config.world.gamemode)
         assertFalse(config.world.forceDefaultGamemode)
@@ -40,16 +44,30 @@ class ConfigTests {
         assertFalse(config.world.hardcore)
         assertEquals(10, config.world.viewDistance)
         assertEquals(6000, config.world.autosaveInterval)
+
+        // Advanced settings
         assertTrue(config.advanced.synchronizeChunkWrites)
         assertTrue(config.advanced.enableJmxMonitoring)
+
+        // Query settings
         assertFalse(config.query.enabled)
         assertEquals(25566, config.query.port)
+
+        // Other settings
+        assertFalse(config.other.bungeecord)
+        assertTrue(config.other.metrics)
+        assertEquals(60, config.other.timeoutTime)
+        assertTrue(config.other.restartOnCrash)
+        assertEquals("./start.sh", config.other.restartScript)
+        assertEquals(5000, config.other.earlyWarningInterval)
+        assertEquals(10000, config.other.earlyWarningDelay)
 
         val modified = config.copy(
             server = config.server.copy(onlineMode = false),
             world = config.world.copy(forceDefaultGamemode = true, hardcore = true),
             advanced = config.advanced.copy(synchronizeChunkWrites = false, enableJmxMonitoring = false),
-            query = config.query.copy(enabled = true)
+            query = config.query.copy(enabled = true),
+            other = config.other.copy(bungeecord = true, metrics = false, restartOnCrash = false)
         )
         assertFalse(modified.server.onlineMode)
         assertTrue(modified.world.forceDefaultGamemode)
@@ -57,18 +75,26 @@ class ConfigTests {
         assertFalse(modified.advanced.synchronizeChunkWrites)
         assertFalse(modified.advanced.enableJmxMonitoring)
         assertTrue(modified.query.enabled)
+        assertTrue(modified.other.bungeecord)
+        assertFalse(modified.other.metrics)
+        assertFalse(modified.other.restartOnCrash)
     }
 
     @Test
     fun `test config defaults`() {
         val config = KryptonConfig()
+
+        // Server settings
         assertEquals("0.0.0.0", config.server.ip)
         assertEquals(25565, config.server.port)
         assertTrue(config.server.onlineMode)
         assertEquals(256, config.server.compressionThreshold)
-        assertEquals(60000, config.server.tickThreshold)
+
+        // Status settings
         assertEquals(Component.text("Krypton is a Minecraft server written in Kotlin!", TextColor.fromHexString("#8000ff")), config.status.motd)
         assertEquals(20, config.status.maxPlayers)
+
+        // World settings
         assertEquals("world", config.world.name)
         assertEquals(Gamemode.SURVIVAL, config.world.gamemode)
         assertFalse(config.world.forceDefaultGamemode)
@@ -76,10 +102,23 @@ class ConfigTests {
         assertFalse(config.world.hardcore)
         assertEquals(10, config.world.viewDistance)
         assertEquals(6000, config.world.autosaveInterval)
+
+        // Advanced settings
         assertTrue(config.advanced.synchronizeChunkWrites)
         assertTrue(config.advanced.enableJmxMonitoring)
+
+        // Query settings
         assertFalse(config.query.enabled)
         assertEquals(25566, config.query.port)
+
+        // Other settings
+        assertFalse(config.other.bungeecord)
+        assertTrue(config.other.metrics)
+        assertEquals(60, config.other.timeoutTime)
+        assertTrue(config.other.restartOnCrash)
+        assertEquals("./start.sh", config.other.restartScript)
+        assertEquals(5000, config.other.earlyWarningInterval)
+        assertEquals(10000, config.other.earlyWarningDelay)
     }
 
     @Test

--- a/server/src/test/resources/config.conf
+++ b/server/src/test/resources/config.conf
@@ -5,7 +5,6 @@ server {
   port = 25565
   online-mode = true
   compression-threshold = 256
-  tick-threshold = 60000
 }
 
 status {
@@ -31,4 +30,17 @@ advanced {
 query {
   enabled = false
   port = 25566
+}
+
+other {
+  bungeecord = false
+  metrics = true # Whether we should enable bStats metrics for the server or not
+
+  # Watchdog settings
+  timeout-time = 60 # The time that the server must be non responsive for before watchdog considers it dead
+  restart-on-crash = true # If we should attempt to restart the server if it crashes
+  restart-script = "./start.sh"
+  restart-message = "Server closed."
+  early-warning-interval = 5000
+  early-warning-delay = 10000
 }


### PR DESCRIPTION
This PR drastically improves the way watchdog detects and reports server freezes, and also adds restart on crash handling.

This is very similar to [Spigot's Watchdog](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/spigot/browse/CraftBukkit-Patches/0029-Watchdog-Thread.patch), with most of Paper's improvements, but also some improvements of my own, but credit still goes to those guys for originally creating this.

There is also two bug fixes in here:
- Fixed errors decoding BungeeCord handshake when BungeeCord support is enabled and the client is not connecting through it
- Fixed metrics Java version showing up in full (e.g. "Java 11.0.1" instead of just "Java 11")