### PR TITLE
Relicense Krypton under LGPL v3

### DIFF
--- a/HEADER.txt
+++ b/HEADER.txt
@@ -1,16 +1,16 @@
-This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+This file is part of the Krypton project, licensed under the GNU General Public License v3.0
 
 Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
 
 This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published
-by the Free Software Foundation, either version 3 of the License, or
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
+GNU General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/HEADER.txt
+++ b/HEADER.txt
@@ -1,0 +1,16 @@
+This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+
+Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/LICENSE
+++ b/LICENSE
@@ -1,24 +1,165 @@
-MIT License
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-Copyright (c) 2021 Callum Seabrook
-Copyright (c) 2021 Alexander Wood
-Copyright (c) 2021 Nicole Barningham
-Copyright (c) 2021 Krypton contributors
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/LICENSE
+++ b/LICENSE
@@ -1,165 +1,674 @@
-                   GNU LESSER GENERAL PUBLIC LICENSE
+                    GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
+                            Preamble
 
-  This version of the GNU Lesser General Public License incorporates
-the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
 
-  0. Additional Definitions.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
 
-  As used herein, "this License" refers to version 3 of the GNU Lesser
-General Public License, and the "GNU GPL" refers to version 3 of the GNU
-General Public License.
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-  "The Library" refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
 
-  An "Application" is any work that makes use of an interface provided
-by the Library, but which is not otherwise based on the Library.
-Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
 
-  A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the "Linked
-Version".
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
 
-  The "Minimal Corresponding Source" for a Combined Work means the
-Corresponding Source for the Combined Work, excluding any source code
-for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
 
-  The "Corresponding Application Code" for a Combined Work means the
-object code and/or source code for the Application, including any data
-and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
 
-  1. Exception to Section 3 of the GNU GPL.
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
 
-  You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.
+  The precise terms and conditions for copying, distribution and
+modification follow.
 
-  2. Conveying Modified Versions.
+                       TERMS AND CONDITIONS
 
-  If you modify a copy of the Library, and, in your modifications, a
-facility refers to a function or data to be supplied by an Application
-that uses the facility (other than as an argument passed when the
-facility is invoked), then you may convey a copy of the modified
-version:
+  0. Definitions.
 
-   a) under this License, provided that you make a good faith effort to
-   ensure that, in the event an Application does not supply the
-   function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or
+  "This License" refers to version 3 of the GNU General Public License.
 
-   b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
 
-  3. Object Code Incorporating Material from Library Header Files.
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
 
-  The object code form of an Application may incorporate material from
-a header file that is part of the Library.  You may convey such object
-code under terms of your choice, provided that, if the incorporated
-material is not limited to numerical parameters, data structure
-layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
 
-   a) Give prominent notice with each copy of the object code that the
-   Library is used in it and that the Library and its use are
-   covered by this License.
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
 
-   b) Accompany the object code with a copy of the GNU GPL and this license
-   document.
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
 
-  4. Combined Works.
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
 
-  You may convey a Combined Work under terms of your choice that,
-taken together, effectively do not restrict modification of the
-portions of the Library contained in the Combined Work and reverse
-engineering for debugging such modifications, if you also do each of
-the following:
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
 
-   a) Give prominent notice with each copy of the Combined Work that
-   the Library is used in it and that the Library and its use are
-   covered by this License.
+  1. Source Code.
 
-   b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
 
-   c) For a Combined Work that displays copyright notices during
-   execution, include the copyright notice for the Library among
-   these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
 
-   d) Do one of the following:
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
 
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
 
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version.
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
 
-   e) Provide Installation Information, but only if you would otherwise
-   be required to provide such information under section 6 of the
-   GNU GPL, and only to the extent that such information is
-   necessary to install and execute a modified version of the
-   Combined Work produced by recombining or relinking the
-   Application with a modified version of the Linked Version. (If
-   you use option 4d0, the Installation Information must accompany
-   the Minimal Corresponding Source and Corresponding Application
-   Code. If you use option 4d1, you must provide the Installation
-   Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)
+  The Corresponding Source for a work in source code form is that
+same work.
 
-  5. Combined Libraries.
+  2. Basic Permissions.
 
-  You may place library facilities that are a work based on the
-Library side by side in a single library together with other library
-facilities that are not Applications and are not covered by this
-License, and convey such a combined library under terms of your
-choice, if you do both of the following:
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
 
-   a) Accompany the combined library with a copy of the same work based
-   on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
 
-   b) Give prominent notice with the combined library that part of it
-   is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
 
-  6. Revised Versions of the GNU Lesser General Public License.
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
 
-  The Free Software Foundation may publish revised and/or new versions
-of the GNU Lesser General Public License from time to time. Such new
-versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
 
-  Each version is given a distinguishing version number. If the
-Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License "or any later version"
-applies to it, you have the option of following the terms and
-conditions either of that published version or of any later version
-published by the Free Software Foundation. If the Library as you
-received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
 
-  If the Library as you received it specifies that a proxy can decide
-whether future versions of the GNU Lesser General Public License shall
-apply, that proxy's public statement of acceptance of any version is
-permanent authorization for you to choose that version for the
-Library.
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/api/HEADER.txt
+++ b/api/HEADER.txt
@@ -1,0 +1,6 @@
+This file is part of the Krypton API, licensed under the MIT license.
+
+Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+
+This project is licensed under the terms of the MIT license.
+For more details, please reference the LICENSE file in the api top-level directory.

--- a/api/LICENSE
+++ b/api/LICENSE
@@ -1,0 +1,24 @@
+MIT License
+
+Copyright (C) 2021 Callum Seabrook
+Copyright (C) 2021 Alexander Wood
+Copyright (C) 2021 Nicole Barningham
+Copyright (C) 2021 Krypton contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -2,6 +2,7 @@ import org.kryptonmc.krypton.applyCommon
 import org.kryptonmc.krypton.applyRepositories
 
 plugins {
+    id("org.cadixdev.licenser")
     `maven-publish`
     signing
 }
@@ -22,4 +23,9 @@ publishing {
 
 signing {
     sign(publishing.publications["mavenKotlin"])
+}
+
+license {
+    header.set(project.resources.text.fromFile("HEADER.txt"))
+    newLine.set(false)
 }

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/Keyed.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/Keyed.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import org.kryptonmc.krypton.api.registry.NamespacedKey

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/Server.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/Server.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import net.kyori.adventure.audience.ForwardingAudience

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/block/Block.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/block/Block.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.block
 
 import org.kryptonmc.krypton.api.inventory.item.Material

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/block/BoundingBox.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/block/BoundingBox.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.block
 
 import org.kryptonmc.krypton.api.space.Vector

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/command/Command.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/command/Command.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.command
 
 /**

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/command/CommandManager.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/command/CommandManager.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.command
 
 import com.mojang.brigadier.tree.LiteralCommandNode

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/command/Sender.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/command/Sender.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.command
 
 import net.kyori.adventure.audience.Audience

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/effect/particle/ParticleEffectBuilders.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/effect/particle/ParticleEffectBuilders.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 @file:JvmName("ParticleUtils")
 package org.kryptonmc.krypton.api.effect.particle
 

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/effect/particle/ParticleEffects.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/effect/particle/ParticleEffects.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.effect.particle
 
 import org.kryptonmc.krypton.api.entity.entities.Player

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/effect/particle/ParticleTypes.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/effect/particle/ParticleTypes.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.effect.particle
 
 import org.kryptonmc.krypton.api.registry.NamespacedKey

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/effect/sound/SoundType.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/effect/sound/SoundType.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.effect.sound
 
 import org.kryptonmc.krypton.api.Keyed

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/entity/Abilities.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/entity/Abilities.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.entity
 
 import org.kryptonmc.krypton.api.entity.entities.Player

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/entity/Hand.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/entity/Hand.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.entity
 
 /**

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/entity/MainHand.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/entity/MainHand.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.entity
 
 /**

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/entity/entities/Player.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/entity/entities/Player.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.entity.entities
 
 import net.kyori.adventure.text.Component

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/event/CancellableEvent.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/event/CancellableEvent.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.event
 
 /**

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/event/Event.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/event/Event.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.event
 
 /**

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/event/EventBus.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/event/EventBus.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.event
 
 /**

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/event/Listener.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/event/Listener.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.event
 
 /**

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/event/ListenerPriority.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/event/ListenerPriority.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.event
 
 /**

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/handshake/HandshakeEvent.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/handshake/HandshakeEvent.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.event.events.handshake
 
 import org.kryptonmc.krypton.api.event.Event

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/login/JoinEvent.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/login/JoinEvent.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.event.events.login
 
 import net.kyori.adventure.extra.kotlin.translatable

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/login/LoginEvent.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/login/LoginEvent.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.event.events.login
 
 import net.kyori.adventure.extra.kotlin.translatable

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/play/ChatEvent.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/play/ChatEvent.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.event.events.play
 
 import org.kryptonmc.krypton.api.entity.entities.Player

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/play/ClientSettingsEvent.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/play/ClientSettingsEvent.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.event.events.play
 
 import org.kryptonmc.krypton.api.entity.entities.Player

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/play/MoveEvent.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/play/MoveEvent.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.event.events.play
 
 import org.kryptonmc.krypton.api.entity.entities.Player

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/play/PermissionCheckEvent.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/play/PermissionCheckEvent.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.event.events.play
 
 import org.kryptonmc.krypton.api.command.Sender

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/play/PluginMessageEvent.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/play/PluginMessageEvent.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.event.events.play
 
 import org.kryptonmc.krypton.api.entity.entities.Player

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/play/QuitEvent.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/play/QuitEvent.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.event.events.play
 
 import net.kyori.adventure.extra.kotlin.translatable

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/ticking/TickEndEvent.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/ticking/TickEndEvent.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.event.events.ticking
 
 import org.kryptonmc.krypton.api.event.Event

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/ticking/TickStartEvent.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/event/events/ticking/TickStartEvent.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.event.events.ticking
 
 import org.kryptonmc.krypton.api.event.Event

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/inventory/Inventory.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/inventory/Inventory.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.inventory
 
 import org.kryptonmc.krypton.api.inventory.item.ItemStack

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/inventory/InventoryHolder.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/inventory/InventoryHolder.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.inventory
 
 /**

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/inventory/InventoryType.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/inventory/InventoryType.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.inventory
 
 import org.kryptonmc.krypton.api.Keyed

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/inventory/PlayerInventory.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/inventory/PlayerInventory.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.inventory
 
 import org.kryptonmc.krypton.api.entity.entities.Player

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/inventory/item/ItemStack.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/inventory/item/ItemStack.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.inventory.item
 
 import org.kryptonmc.krypton.api.inventory.item.meta.ItemMeta

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/inventory/item/Material.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/inventory/item/Material.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.inventory.item
 
 import net.kyori.adventure.util.Index

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/inventory/item/dsl/ItemBuilder.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/inventory/item/dsl/ItemBuilder.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.inventory.item.dsl
 
 import net.kyori.adventure.text.Component

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/inventory/item/dsl/ItemDSL.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/inventory/item/dsl/ItemDSL.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.inventory.item.dsl
 
 import net.kyori.adventure.text.Component

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/inventory/item/meta/ItemMeta.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/inventory/item/meta/ItemMeta.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.inventory.item.meta
 
 import net.kyori.adventure.text.Component

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/plugin/Plugin.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/plugin/Plugin.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.plugin
 
 import org.apache.logging.log4j.Logger

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/plugin/PluginDescriptionFile.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/plugin/PluginDescriptionFile.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.plugin
 
 import kotlinx.serialization.Serializable

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/plugin/PluginLoadState.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/plugin/PluginLoadState.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.plugin
 
 /**

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/plugin/PluginManager.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/plugin/PluginManager.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.plugin
 
 import java.nio.file.Path

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/registry/NamespacedKey.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/registry/NamespacedKey.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 @file:JvmName("KeyUtils")
 package org.kryptonmc.krypton.api.registry
 

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/scheduling/Scheduler.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/scheduling/Scheduler.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.scheduling
 
 import org.kryptonmc.krypton.api.plugin.Plugin

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/scheduling/Task.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/scheduling/Task.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.scheduling
 
 import org.kryptonmc.krypton.api.plugin.Plugin

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/scheduling/TaskState.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/scheduling/TaskState.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.scheduling
 
 /**

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/service/ServiceProvider.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/service/ServiceProvider.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.service
 
 import org.kryptonmc.krypton.api.plugin.Plugin

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/service/ServicesManager.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/service/ServicesManager.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.service
 
 import org.kryptonmc.krypton.api.plugin.Plugin

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/space/Direction.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/space/Direction.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.space
 
 /**

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/space/Position.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/space/Position.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 @file:Suppress("INAPPLICABLE_JVM_NAME", "unused")
 
 package org.kryptonmc.krypton.api.space

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/space/Vector.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/space/Vector.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 @file:Suppress("unused", "MemberVisibilityCanBePrivate")
 @file:JvmName("NumberUtils")
 package org.kryptonmc.krypton.api.space

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/status/StatusInfo.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/status/StatusInfo.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.status
 
 import net.kyori.adventure.text.Component

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/world/Biome.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/world/Biome.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.world
 
 import org.kryptonmc.krypton.api.Keyed

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/world/Difficulty.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/world/Difficulty.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.world
 
 import kotlinx.serialization.Serializable

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/world/Gamemode.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/world/Gamemode.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.world
 
 import kotlinx.serialization.Serializable

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/world/Location.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/world/Location.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.world
 
 import org.jetbrains.annotations.Contract

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/world/World.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/world/World.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.world
 
 import org.kryptonmc.krypton.api.Server

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/world/WorldBorder.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/world/WorldBorder.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.world
 
 /**

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/world/WorldManager.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/world/WorldManager.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.world
 
 import org.kryptonmc.krypton.api.Server

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/world/chunk/Chunk.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/world/chunk/Chunk.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.world.chunk
 
 import org.kryptonmc.krypton.api.block.Block

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/world/scoreboard/Objective.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/world/scoreboard/Objective.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.world.scoreboard
 
 import net.kyori.adventure.text.Component

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/world/scoreboard/Score.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/world/scoreboard/Score.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.world.scoreboard
 
 import org.kryptonmc.krypton.api.entity.entities.Player

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/world/scoreboard/Scoreboard.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/world/scoreboard/Scoreboard.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.world.scoreboard
 
 import org.kryptonmc.krypton.api.entity.entities.Player

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/world/scoreboard/Team.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/world/scoreboard/Team.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.world.scoreboard
 
 import net.kyori.adventure.text.Component

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/world/scoreboard/criteria/Criteria.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/world/scoreboard/criteria/Criteria.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.world.scoreboard.criteria
 
 /**

--- a/api/src/main/kotlin/org/kryptonmc/krypton/api/world/scoreboard/criteria/Criterion.kt
+++ b/api/src/main/kotlin/org/kryptonmc/krypton/api/world/scoreboard/criteria/Criterion.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.world.scoreboard.criteria
 
 /**

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/AbilitiesTests.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/AbilitiesTests.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import org.kryptonmc.krypton.api.entity.Abilities

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/BiomeTests.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/BiomeTests.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import org.kryptonmc.krypton.api.world.Biome

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/BoundingBoxTests.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/BoundingBoxTests.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import org.kryptonmc.krypton.api.block.BoundingBox

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/ClientSettingsTests.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/ClientSettingsTests.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import org.kryptonmc.krypton.api.event.events.play.ClientSettingsEvent

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/CommandTest.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/CommandTest.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import kotlin.test.Test

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/DirectionTest.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/DirectionTest.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import org.kryptonmc.krypton.api.space.Direction

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/EventTests.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/EventTests.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import net.kyori.adventure.text.Component

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/GamemodeTests.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/GamemodeTests.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import org.kryptonmc.krypton.api.world.Gamemode

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/InventoryTests.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/InventoryTests.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import io.mockk.every

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/LocationTests.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/LocationTests.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import org.junit.jupiter.api.assertThrows

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/NamespacedKeyTests.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/NamespacedKeyTests.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import kotlinx.serialization.decodeFromString

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/ParticleEffectTests.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/ParticleEffectTests.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import io.mockk.every

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/ParticleTests.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/ParticleTests.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import io.mockk.every

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/PermissionTests.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/PermissionTests.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import io.mockk.every

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/PluginTests.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/PluginTests.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import io.mockk.verify

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/PositionTests.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/PositionTests.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import org.junit.jupiter.api.RepeatedTest

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/ScoreboardTests.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/ScoreboardTests.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import net.kyori.adventure.text.Component.text

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/WorldTests.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/WorldTests.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import org.kryptonmc.krypton.api.world.WorldVersion

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/common.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/common.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api
 
 import com.mojang.brigadier.tree.LiteralCommandNode

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/dummy/DummyCancellableEvent.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/dummy/DummyCancellableEvent.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.dummy
 
 import org.kryptonmc.krypton.api.event.CancellableEvent

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/dummy/DummyCommand.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/dummy/DummyCommand.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.dummy
 
 import org.kryptonmc.krypton.api.command.Command

--- a/api/src/test/kotlin/org/kryptonmc/krypton/api/dummy/DummyWorld.kt
+++ b/api/src/test/kotlin/org/kryptonmc/krypton/api/dummy/DummyWorld.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.krypton.api.dummy
 
 import io.mockk.mockk

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
     kotlin("plugin.serialization") version "1.5.0"
     id("org.jetbrains.dokka") version "1.4.30"
     id("info.solidsoft.pitest") version "1.6.0"
+    id("org.cadixdev.licenser") version "0.6.0" apply false
     `maven-publish`
     signing
 }

--- a/buildSrc/src/main/kotlin/org/kryptonmc/krypton/Versions.kt
+++ b/buildSrc/src/main/kotlin/org/kryptonmc/krypton/Versions.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton
 
 object Versions {

--- a/buildSrc/src/main/kotlin/org/kryptonmc/krypton/dependencies.kt
+++ b/buildSrc/src/main/kotlin/org/kryptonmc/krypton/dependencies.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton
 
 import org.gradle.api.artifacts.dsl.DependencyHandler

--- a/buildSrc/src/main/kotlin/org/kryptonmc/krypton/publishing.kt
+++ b/buildSrc/src/main/kotlin/org/kryptonmc/krypton/publishing.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton
 
 import org.gradle.api.Project

--- a/buildSrc/src/main/kotlin/org/kryptonmc/krypton/utils.kt
+++ b/buildSrc/src/main/kotlin/org/kryptonmc/krypton/utils.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton
 
 import org.gradle.api.Project

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -9,8 +9,9 @@ import org.kryptonmc.krypton.log4j
 import org.kryptonmc.krypton.netty
 
 plugins {
-    `java-library`
     id("com.github.johnrengelman.shadow") version "7.0.0"
+    id("org.cadixdev.licenser")
+    `java-library`
     application
     `maven-publish`
     signing
@@ -109,4 +110,10 @@ publishing {
 
 signing {
     sign(publishing.publications["mavenKotlin"])
+}
+
+license {
+    header.set(project.rootProject.resources.text.fromFile("HEADER.txt"))
+    newLine.set(false)
+    exclude("**/*.properties", "**/*.conf", "**/*.json")
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/Krypton.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/Krypton.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton

--- a/server/src/main/kotlin/org/kryptonmc/krypton/Krypton.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/Krypton.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton
 
 import com.github.ajalt.clikt.core.CliktCommand

--- a/server/src/main/kotlin/org/kryptonmc/krypton/KryptonServer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/KryptonServer.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton

--- a/server/src/main/kotlin/org/kryptonmc/krypton/KryptonServer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/KryptonServer.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton
 
 import com.typesafe.config.ConfigFactory

--- a/server/src/main/kotlin/org/kryptonmc/krypton/Metrics.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/Metrics.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton

--- a/server/src/main/kotlin/org/kryptonmc/krypton/Metrics.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/Metrics.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton
 
 import org.apache.logging.log4j.Logger

--- a/server/src/main/kotlin/org/kryptonmc/krypton/NettyProcess.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/NettyProcess.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton

--- a/server/src/main/kotlin/org/kryptonmc/krypton/NettyProcess.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/NettyProcess.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton
 
 import io.netty.bootstrap.ServerBootstrap

--- a/server/src/main/kotlin/org/kryptonmc/krypton/ServerStorage.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/ServerStorage.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton
 
 import java.util.concurrent.atomic.AtomicInteger

--- a/server/src/main/kotlin/org/kryptonmc/krypton/ServerStorage.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/ServerStorage.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton

--- a/server/src/main/kotlin/org/kryptonmc/krypton/WatchdogProcess.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/WatchdogProcess.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton

--- a/server/src/main/kotlin/org/kryptonmc/krypton/WatchdogProcess.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/WatchdogProcess.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton
 
 import org.apache.logging.log4j.Logger

--- a/server/src/main/kotlin/org/kryptonmc/krypton/auth/GameProfile.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/auth/GameProfile.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.auth
 
 import kotlinx.serialization.KSerializer

--- a/server/src/main/kotlin/org/kryptonmc/krypton/auth/GameProfile.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/auth/GameProfile.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.auth

--- a/server/src/main/kotlin/org/kryptonmc/krypton/auth/ProfileProperty.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/auth/ProfileProperty.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.auth

--- a/server/src/main/kotlin/org/kryptonmc/krypton/auth/ProfileProperty.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/auth/ProfileProperty.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.auth
 
 import kotlinx.serialization.Serializable

--- a/server/src/main/kotlin/org/kryptonmc/krypton/auth/exceptions/AuthenticationException.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/auth/exceptions/AuthenticationException.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.auth.exceptions

--- a/server/src/main/kotlin/org/kryptonmc/krypton/auth/exceptions/AuthenticationException.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/auth/exceptions/AuthenticationException.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.auth.exceptions
 
 /**

--- a/server/src/main/kotlin/org/kryptonmc/krypton/auth/requests/MojangSessionService.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/auth/requests/MojangSessionService.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.auth.requests

--- a/server/src/main/kotlin/org/kryptonmc/krypton/auth/requests/MojangSessionService.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/auth/requests/MojangSessionService.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.auth.requests
 
 import com.github.benmanes.caffeine.cache.Cache

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/BrigadierCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/BrigadierCommand.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.command

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/BrigadierCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/BrigadierCommand.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command
 
 import com.mojang.brigadier.tree.LiteralCommandNode

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/CommandScope.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/CommandScope.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.command

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/CommandScope.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/CommandScope.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command
 
 import kotlinx.coroutines.CoroutineScope

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/KryptonCommandManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/KryptonCommandManager.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.command

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/KryptonCommandManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/KryptonCommandManager.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command
 
 import com.mojang.brigadier.CommandDispatcher

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/KryptonSender.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/KryptonSender.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.command

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/KryptonSender.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/KryptonSender.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command
 
 import org.kryptonmc.krypton.KryptonServer

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/ArgumentTypes.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/ArgumentTypes.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command.argument
 
 import com.mojang.brigadier.arguments.ArgumentType

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/ArgumentTypes.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/ArgumentTypes.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.command.argument

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/ArgumentSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/ArgumentSerializer.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command.argument.serializer
 
 import com.mojang.brigadier.arguments.ArgumentType

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/ArgumentSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/ArgumentSerializer.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.command.argument.serializer

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/EmptyArgumentSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/EmptyArgumentSerializer.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command.argument.serializer
 
 import com.mojang.brigadier.arguments.ArgumentType

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/EmptyArgumentSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/EmptyArgumentSerializer.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.command.argument.serializer

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/brigadier/DoubleArgumentSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/brigadier/DoubleArgumentSerializer.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.command.argument.serializer.brigadier

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/brigadier/DoubleArgumentSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/brigadier/DoubleArgumentSerializer.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command.argument.serializer.brigadier
 
 import com.mojang.brigadier.arguments.DoubleArgumentType

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/brigadier/FloatArgumentSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/brigadier/FloatArgumentSerializer.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.command.argument.serializer.brigadier

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/brigadier/FloatArgumentSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/brigadier/FloatArgumentSerializer.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command.argument.serializer.brigadier
 
 import com.mojang.brigadier.arguments.FloatArgumentType

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/brigadier/IntegerArgumentSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/brigadier/IntegerArgumentSerializer.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.command.argument.serializer.brigadier

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/brigadier/IntegerArgumentSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/brigadier/IntegerArgumentSerializer.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command.argument.serializer.brigadier
 
 import com.mojang.brigadier.arguments.IntegerArgumentType

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/brigadier/LongArgumentSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/brigadier/LongArgumentSerializer.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command.argument.serializer.brigadier
 
 import com.mojang.brigadier.arguments.LongArgumentType

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/brigadier/LongArgumentSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/brigadier/LongArgumentSerializer.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.command.argument.serializer.brigadier

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/brigadier/StringArgumentSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/brigadier/StringArgumentSerializer.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.command.argument.serializer.brigadier

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/brigadier/StringArgumentSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/brigadier/StringArgumentSerializer.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command.argument.serializer.brigadier
 
 import com.mojang.brigadier.arguments.StringArgumentType

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/DebugCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/DebugCommand.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command.commands
 
 import com.mojang.brigadier.Message

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/DebugCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/DebugCommand.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.command.commands

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/RestartCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/RestartCommand.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command.commands
 
 import net.kyori.adventure.text.Component

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/RestartCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/RestartCommand.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.command.commands

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/StopCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/StopCommand.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command.commands
 
 import net.kyori.adventure.text.Component

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/StopCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/StopCommand.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.command.commands

--- a/server/src/main/kotlin/org/kryptonmc/krypton/console/ConsoleSender.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/console/ConsoleSender.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.console
 
 import net.kyori.adventure.audience.MessageType

--- a/server/src/main/kotlin/org/kryptonmc/krypton/console/ConsoleSender.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/console/ConsoleSender.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.console

--- a/server/src/main/kotlin/org/kryptonmc/krypton/console/KryptonConsole.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/console/KryptonConsole.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.console

--- a/server/src/main/kotlin/org/kryptonmc/krypton/console/KryptonConsole.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/console/KryptonConsole.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.console
 
 import net.minecrell.terminalconsole.SimpleTerminalConsole

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/Attributes.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/Attributes.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.entity
 
 import net.kyori.adventure.util.Index

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/Attributes.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/Attributes.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.entity

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/Entity.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/Entity.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.entity
 
 import org.kryptonmc.krypton.world.LocationBuilder

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/Entity.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/Entity.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.entity

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/EntityType.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/EntityType.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.entity

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/EntityType.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/EntityType.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.entity
 
 import org.kryptonmc.krypton.api.registry.NamespacedKey

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/Hand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/Hand.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.entity
 
 /**

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/Hand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/Hand.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.entity

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/MobEffectType.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/MobEffectType.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.entity

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/MobEffectType.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/MobEffectType.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.entity
 
 enum class MobEffectType(private val id: Int) {

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/Slot.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/Slot.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.entity
 
 import net.kyori.adventure.nbt.CompoundBinaryTag

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/Slot.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/Slot.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.entity

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/entities/Entity.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/entities/Entity.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.entity.entities
 
 import net.kyori.adventure.text.Component

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/entities/Entity.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/entities/Entity.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.entity.entities

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/entities/KryptonPlayer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/entities/KryptonPlayer.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.entity.entities
 
 import kotlinx.coroutines.Dispatchers

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/entities/KryptonPlayer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/entities/KryptonPlayer.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.entity.entities

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/entities/data/VillagerData.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/entities/data/VillagerData.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.entity.entities.data
 
 /**

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/entities/data/VillagerData.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/entities/data/VillagerData.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.entity.entities.data

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/entities/data/VillagerProfession.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/entities/data/VillagerProfession.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.entity.entities.data
 
 import org.kryptonmc.krypton.api.registry.NamespacedKey

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/entities/data/VillagerProfession.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/entities/data/VillagerProfession.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.entity.entities.data

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/entities/data/VillagerType.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/entities/data/VillagerType.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.entity.entities.data
 
 import org.kryptonmc.krypton.api.registry.NamespacedKey

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/entities/data/VillagerType.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/entities/data/VillagerType.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.entity.entities.data

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/memory/Brain.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/memory/Brain.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.entity.memory
 
 import net.kyori.adventure.nbt.CompoundBinaryTag

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/memory/Brain.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/memory/Brain.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.entity.memory

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/memory/Memories.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/memory/Memories.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.entity.memory

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/memory/Memories.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/memory/Memories.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.entity.memory
 
 import org.kryptonmc.krypton.api.registry.NamespacedKey

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/metadata/EntityMetadata.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/metadata/EntityMetadata.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.entity.metadata
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/metadata/EntityMetadata.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/metadata/EntityMetadata.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.entity.metadata

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/metadata/LivingEntityMetadata.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/metadata/LivingEntityMetadata.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.entity.metadata
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/metadata/LivingEntityMetadata.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/metadata/LivingEntityMetadata.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.entity.metadata

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/metadata/PlayerMetadata.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/metadata/PlayerMetadata.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.entity.metadata
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/metadata/PlayerMetadata.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/metadata/PlayerMetadata.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.entity.metadata

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/metadata/Pose.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/metadata/Pose.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.entity.metadata
 
 /**

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/metadata/Pose.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/metadata/Pose.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.entity.metadata

--- a/server/src/main/kotlin/org/kryptonmc/krypton/event/EventHandlerMethod.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/event/EventHandlerMethod.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.event
 
 import java.lang.reflect.Method

--- a/server/src/main/kotlin/org/kryptonmc/krypton/event/EventHandlerMethod.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/event/EventHandlerMethod.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.event

--- a/server/src/main/kotlin/org/kryptonmc/krypton/event/KryptonEventBus.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/event/KryptonEventBus.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.event

--- a/server/src/main/kotlin/org/kryptonmc/krypton/event/KryptonEventBus.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/event/KryptonEventBus.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.event
 
 import org.kryptonmc.krypton.api.event.EventBus

--- a/server/src/main/kotlin/org/kryptonmc/krypton/inventory/KryptonInventory.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/inventory/KryptonInventory.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.inventory

--- a/server/src/main/kotlin/org/kryptonmc/krypton/inventory/KryptonInventory.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/inventory/KryptonInventory.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.inventory
 
 import org.kryptonmc.krypton.api.inventory.Inventory

--- a/server/src/main/kotlin/org/kryptonmc/krypton/inventory/KryptonPlayerInventory.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/inventory/KryptonPlayerInventory.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.inventory

--- a/server/src/main/kotlin/org/kryptonmc/krypton/inventory/KryptonPlayerInventory.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/inventory/KryptonPlayerInventory.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.inventory
 
 import org.kryptonmc.krypton.api.inventory.InventoryType

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/ChannelHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/ChannelHandler.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet
 
 import io.netty.channel.ChannelHandlerContext

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/ChannelHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/ChannelHandler.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/Packet.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/Packet.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/Packet.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/Packet.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/PacketLoader.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/PacketLoader.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet
 
 import org.kryptonmc.krypton.packet.`in`.handshake.PacketInHandshake

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/PacketLoader.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/PacketLoader.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/data/ClientSettings.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/data/ClientSettings.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.data

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/data/ClientSettings.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/data/ClientSettings.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.data
 
 import org.kryptonmc.krypton.api.event.events.play.SkinSettings

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/data/HandshakeData.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/data/HandshakeData.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.data

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/data/HandshakeData.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/data/HandshakeData.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.data
 
 import org.kryptonmc.krypton.packet.state.PacketState

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/data/StatusResponse.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/data/StatusResponse.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.data

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/data/StatusResponse.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/data/StatusResponse.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.data
 
 import kotlinx.serialization.SerialName

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/HandshakeHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/HandshakeHandler.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.handlers

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/HandshakeHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/HandshakeHandler.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.handlers
 
 import net.kyori.adventure.extra.kotlin.text

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/LoginHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/LoginHandler.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.handlers

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/LoginHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/LoginHandler.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.handlers
 
 import kotlinx.coroutines.Dispatchers

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/PacketHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/PacketHandler.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.handlers

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/PacketHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/PacketHandler.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.handlers
 
 import org.kryptonmc.krypton.KryptonServer

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/PlayHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/PlayHandler.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.handlers
 
 import com.mojang.brigadier.StringReader

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/PlayHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/PlayHandler.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.handlers

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/StatusHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/StatusHandler.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.handlers

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/StatusHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/handlers/StatusHandler.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.handlers
 
 import org.kryptonmc.krypton.KryptonServer

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/handshake/PacketInHandshake.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/handshake/PacketInHandshake.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.`in`.handshake

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/handshake/PacketInHandshake.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/handshake/PacketInHandshake.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.`in`.handshake
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/login/PacketInEncryptionResponse.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/login/PacketInEncryptionResponse.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.`in`.login

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/login/PacketInEncryptionResponse.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/login/PacketInEncryptionResponse.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.`in`.login
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/login/PacketInLoginStart.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/login/PacketInLoginStart.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.`in`.login

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/login/PacketInLoginStart.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/login/PacketInLoginStart.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.`in`.login
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInAnimation.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInAnimation.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.`in`.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInAnimation.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInAnimation.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.`in`.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInChat.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInChat.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.`in`.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInChat.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInChat.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.`in`.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInClientSettings.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInClientSettings.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.`in`.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInClientSettings.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInClientSettings.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.`in`.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInCreativeInventoryAction.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInCreativeInventoryAction.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.`in`.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInCreativeInventoryAction.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInCreativeInventoryAction.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.`in`.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInEntityAction.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInEntityAction.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.`in`.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInEntityAction.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInEntityAction.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.`in`.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInHeldItemChange.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInHeldItemChange.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.`in`.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInHeldItemChange.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInHeldItemChange.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.`in`.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInKeepAlive.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInKeepAlive.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.`in`.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInKeepAlive.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInKeepAlive.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.`in`.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInPlayerAbilities.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInPlayerAbilities.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.`in`.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInPlayerAbilities.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInPlayerAbilities.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.`in`.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInPlayerBlockPlacement.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInPlayerBlockPlacement.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.`in`.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInPlayerBlockPlacement.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInPlayerBlockPlacement.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.`in`.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInPlayerMovement.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInPlayerMovement.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.`in`.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInPlayerMovement.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInPlayerMovement.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.`in`.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInPluginMessage.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInPluginMessage.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.`in`.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInPluginMessage.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInPluginMessage.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.`in`.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInTabComplete.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInTabComplete.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.`in`.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInTabComplete.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInTabComplete.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.`in`.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInTeleportConfirm.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInTeleportConfirm.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.`in`.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInTeleportConfirm.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInTeleportConfirm.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.`in`.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/status/PacketInPing.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/status/PacketInPing.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.`in`.status

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/status/PacketInPing.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/status/PacketInPing.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.`in`.status
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/status/PacketInStatusRequest.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/status/PacketInStatusRequest.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.`in`.status

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/status/PacketInStatusRequest.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/status/PacketInStatusRequest.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.`in`.status
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/login/PacketOutEncryptionRequest.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/login/PacketOutEncryptionRequest.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.login
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/login/PacketOutEncryptionRequest.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/login/PacketOutEncryptionRequest.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.login

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/login/PacketOutLoginDisconnect.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/login/PacketOutLoginDisconnect.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.login
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/login/PacketOutLoginDisconnect.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/login/PacketOutLoginDisconnect.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.login

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/login/PacketOutLoginSuccess.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/login/PacketOutLoginSuccess.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.login
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/login/PacketOutLoginSuccess.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/login/PacketOutLoginSuccess.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.login

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/login/PacketOutSetCompression.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/login/PacketOutSetCompression.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.login
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/login/PacketOutSetCompression.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/login/PacketOutSetCompression.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.login

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutAbilities.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutAbilities.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutAbilities.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutAbilities.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutBlockChange.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutBlockChange.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutBlockChange.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutBlockChange.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutChangeGameState.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutChangeGameState.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutChangeGameState.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutChangeGameState.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutChunkData.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutChunkData.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutChunkData.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutChunkData.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutDeclareCommands.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutDeclareCommands.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import com.mojang.brigadier.tree.ArgumentCommandNode

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutDeclareCommands.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutDeclareCommands.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutDeclareRecipes.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutDeclareRecipes.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutDeclareRecipes.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutDeclareRecipes.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutDisconnect.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutDisconnect.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutDisconnect.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutDisconnect.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutHeldItemChange.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutHeldItemChange.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutHeldItemChange.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutHeldItemChange.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutJoinGame.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutJoinGame.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutJoinGame.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutJoinGame.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutKeepAlive.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutKeepAlive.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutKeepAlive.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutKeepAlive.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutParticles.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutParticles.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutParticles.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutParticles.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutPlayerInfo.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutPlayerInfo.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutPlayerInfo.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutPlayerInfo.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutPlayerPositionAndLook.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutPlayerPositionAndLook.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutPlayerPositionAndLook.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutPlayerPositionAndLook.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutPluginMessage.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutPluginMessage.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutPluginMessage.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutPluginMessage.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutServerDifficulty.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutServerDifficulty.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutServerDifficulty.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutServerDifficulty.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutSpawnPosition.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutSpawnPosition.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutSpawnPosition.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutSpawnPosition.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutTags.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutTags.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutTags.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutTags.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutTimeUpdate.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutTimeUpdate.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutTimeUpdate.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutTimeUpdate.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutUnloadChunk.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutUnloadChunk.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutUnloadChunk.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutUnloadChunk.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutUnlockRecipes.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutUnlockRecipes.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutUnlockRecipes.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutUnlockRecipes.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutUpdateLight.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutUpdateLight.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutUpdateLight.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutUpdateLight.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutUpdateViewPosition.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutUpdateViewPosition.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutUpdateViewPosition.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutUpdateViewPosition.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutWindowItems.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutWindowItems.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutWindowItems.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutWindowItems.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutWorldBorder.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutWorldBorder.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutWorldBorder.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutWorldBorder.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/chat/PacketOutChat.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/chat/PacketOutChat.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.chat
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/chat/PacketOutChat.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/chat/PacketOutChat.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play.chat

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/chat/PacketOutPlayerListHeaderFooter.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/chat/PacketOutPlayerListHeaderFooter.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.chat
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/chat/PacketOutPlayerListHeaderFooter.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/chat/PacketOutPlayerListHeaderFooter.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play.chat

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/chat/PacketOutTabComplete.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/chat/PacketOutTabComplete.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play.chat

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/chat/PacketOutTabComplete.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/chat/PacketOutTabComplete.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.chat
 
 import com.mojang.brigadier.Message

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/chat/PacketOutTitle.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/chat/PacketOutTitle.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.chat
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/chat/PacketOutTitle.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/chat/PacketOutTitle.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play.chat

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityAnimation.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityAnimation.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.entity
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityAnimation.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityAnimation.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play.entity

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityDestroy.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityDestroy.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.entity
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityDestroy.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityDestroy.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play.entity

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityMetadata.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityMetadata.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.entity
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityMetadata.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityMetadata.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play.entity

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityMovement.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityMovement.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.entity
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityMovement.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityMovement.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play.entity

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityProperties.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityProperties.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.entity
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityProperties.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityProperties.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play.entity

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityStatus.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityStatus.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.entity
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityStatus.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityStatus.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play.entity

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/spawn/PacketOutSpawnEntity.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/spawn/PacketOutSpawnEntity.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play.entity.spawn

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/spawn/PacketOutSpawnEntity.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/spawn/PacketOutSpawnEntity.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.entity.spawn
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/spawn/PacketOutSpawnPlayer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/spawn/PacketOutSpawnPlayer.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play.entity.spawn

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/spawn/PacketOutSpawnPlayer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/spawn/PacketOutSpawnPlayer.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.entity.spawn
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/scoreboard/PacketOutDisplayScoreboard.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/scoreboard/PacketOutDisplayScoreboard.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.scoreboard
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/scoreboard/PacketOutDisplayScoreboard.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/scoreboard/PacketOutDisplayScoreboard.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play.scoreboard

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/scoreboard/PacketOutScoreboardObjective.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/scoreboard/PacketOutScoreboardObjective.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.scoreboard
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/scoreboard/PacketOutScoreboardObjective.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/scoreboard/PacketOutScoreboardObjective.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play.scoreboard

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/scoreboard/PacketOutScoreboardScore.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/scoreboard/PacketOutScoreboardScore.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.scoreboard
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/scoreboard/PacketOutScoreboardScore.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/scoreboard/PacketOutScoreboardScore.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play.scoreboard

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/scoreboard/PacketOutScoreboardTeam.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/scoreboard/PacketOutScoreboardTeam.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.scoreboard
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/scoreboard/PacketOutScoreboardTeam.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/scoreboard/PacketOutScoreboardTeam.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.play.scoreboard

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/status/PacketOutPong.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/status/PacketOutPong.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.status

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/status/PacketOutPong.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/status/PacketOutPong.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.status
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/status/PacketOutStatusResponse.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/status/PacketOutStatusResponse.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.out.status

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/status/PacketOutStatusResponse.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/status/PacketOutStatusResponse.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.status
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/session/Session.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/session/Session.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.session
 
 import io.netty.channel.Channel

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/session/Session.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/session/Session.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.session

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/session/SessionManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/session/SessionManager.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.session
 
 import kotlinx.coroutines.Dispatchers

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/session/SessionManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/session/SessionManager.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.session

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/state/LoginPacket.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/state/LoginPacket.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.state
 
 import org.kryptonmc.krypton.packet.Packet

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/state/LoginPacket.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/state/LoginPacket.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.state

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/state/PacketState.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/state/PacketState.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.state
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/state/PacketState.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/state/PacketState.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.state

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/state/PlayPacket.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/state/PlayPacket.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.state
 
 import org.kryptonmc.krypton.packet.Packet

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/state/PlayPacket.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/state/PlayPacket.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.state

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/state/StatusPacket.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/state/StatusPacket.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.state
 
 import org.kryptonmc.krypton.packet.Packet

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/state/StatusPacket.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/state/StatusPacket.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.state

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/LegacyQueryHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/LegacyQueryHandler.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.transformers

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/LegacyQueryHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/LegacyQueryHandler.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.transformers
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketCompressor.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketCompressor.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.transformers

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketCompressor.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketCompressor.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.transformers
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketDecoder.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketDecoder.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.transformers

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketDecoder.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketDecoder.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.transformers
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketDecompressor.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketDecompressor.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.transformers

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketDecompressor.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketDecompressor.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.transformers
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketDecrypter.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketDecrypter.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.transformers

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketDecrypter.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketDecrypter.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.transformers
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketEncoder.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketEncoder.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.transformers

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketEncoder.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketEncoder.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.transformers
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketEncrypter.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketEncrypter.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.transformers

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketEncrypter.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/PacketEncrypter.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.transformers
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/SizeDecoder.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/SizeDecoder.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.transformers

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/SizeDecoder.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/SizeDecoder.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.transformers
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/SizeEncoder.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/SizeEncoder.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.packet.transformers

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/SizeEncoder.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/transformers/SizeEncoder.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.transformers
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/plugin/KryptonPluginManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/plugin/KryptonPluginManager.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.plugin

--- a/server/src/main/kotlin/org/kryptonmc/krypton/plugin/KryptonPluginManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/plugin/KryptonPluginManager.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.plugin
 
 import com.typesafe.config.ConfigFactory

--- a/server/src/main/kotlin/org/kryptonmc/krypton/plugin/PluginClassLoader.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/plugin/PluginClassLoader.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.plugin
 
 import java.net.URL

--- a/server/src/main/kotlin/org/kryptonmc/krypton/plugin/PluginClassLoader.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/plugin/PluginClassLoader.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.plugin

--- a/server/src/main/kotlin/org/kryptonmc/krypton/registry/Registries.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/registry/Registries.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.registry

--- a/server/src/main/kotlin/org/kryptonmc/krypton/registry/Registries.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/registry/Registries.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.registry
 
 import kotlinx.serialization.decodeFromString

--- a/server/src/main/kotlin/org/kryptonmc/krypton/registry/Registry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/registry/Registry.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.registry

--- a/server/src/main/kotlin/org/kryptonmc/krypton/registry/Registry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/registry/Registry.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.registry
 
 /**

--- a/server/src/main/kotlin/org/kryptonmc/krypton/registry/biomes/BiomeRegistry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/registry/biomes/BiomeRegistry.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.registry.biomes

--- a/server/src/main/kotlin/org/kryptonmc/krypton/registry/biomes/BiomeRegistry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/registry/biomes/BiomeRegistry.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.registry.biomes
 
 import kotlinx.serialization.SerialName

--- a/server/src/main/kotlin/org/kryptonmc/krypton/registry/dimensions/DimensionRegistry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/registry/dimensions/DimensionRegistry.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.registry.dimensions

--- a/server/src/main/kotlin/org/kryptonmc/krypton/registry/dimensions/DimensionRegistry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/registry/dimensions/DimensionRegistry.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.registry.dimensions
 
 import kotlinx.serialization.SerialName

--- a/server/src/main/kotlin/org/kryptonmc/krypton/registry/impl/DefaultedRegistry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/registry/impl/DefaultedRegistry.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.registry.impl

--- a/server/src/main/kotlin/org/kryptonmc/krypton/registry/impl/DefaultedRegistry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/registry/impl/DefaultedRegistry.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.registry.impl
 
 // TODO: Evaluate the usefulness of this class

--- a/server/src/main/kotlin/org/kryptonmc/krypton/registry/impl/MappedRegistry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/registry/impl/MappedRegistry.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.registry.impl

--- a/server/src/main/kotlin/org/kryptonmc/krypton/registry/impl/MappedRegistry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/registry/impl/MappedRegistry.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.registry.impl
 
 import org.kryptonmc.krypton.registry.Registry

--- a/server/src/main/kotlin/org/kryptonmc/krypton/registry/json/JSONBlocks.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/registry/json/JSONBlocks.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.registry.json

--- a/server/src/main/kotlin/org/kryptonmc/krypton/registry/json/JSONBlocks.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/registry/json/JSONBlocks.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.registry.json
 
 import kotlinx.serialization.Serializable

--- a/server/src/main/kotlin/org/kryptonmc/krypton/registry/json/JSONRegistry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/registry/json/JSONRegistry.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.registry.json

--- a/server/src/main/kotlin/org/kryptonmc/krypton/registry/json/JSONRegistry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/registry/json/JSONRegistry.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.registry.json
 
 import kotlinx.serialization.SerialName

--- a/server/src/main/kotlin/org/kryptonmc/krypton/registry/tags/TagManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/registry/tags/TagManager.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.registry.tags
 
 import kotlinx.serialization.decodeFromString

--- a/server/src/main/kotlin/org/kryptonmc/krypton/registry/tags/TagManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/registry/tags/TagManager.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.registry.tags

--- a/server/src/main/kotlin/org/kryptonmc/krypton/registry/tags/Tags.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/registry/tags/Tags.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.registry.tags
 
 import kotlinx.serialization.Serializable

--- a/server/src/main/kotlin/org/kryptonmc/krypton/registry/tags/Tags.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/registry/tags/Tags.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.registry.tags

--- a/server/src/main/kotlin/org/kryptonmc/krypton/scheduling/KryptonScheduler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/scheduling/KryptonScheduler.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.scheduling
 
 import org.kryptonmc.krypton.api.plugin.Plugin

--- a/server/src/main/kotlin/org/kryptonmc/krypton/scheduling/KryptonScheduler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/scheduling/KryptonScheduler.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.scheduling

--- a/server/src/main/kotlin/org/kryptonmc/krypton/scheduling/KryptonTask.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/scheduling/KryptonTask.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.scheduling
 
 import org.kryptonmc.krypton.api.plugin.Plugin

--- a/server/src/main/kotlin/org/kryptonmc/krypton/scheduling/KryptonTask.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/scheduling/KryptonTask.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.scheduling

--- a/server/src/main/kotlin/org/kryptonmc/krypton/serializers/ComponentSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/serializers/ComponentSerializer.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.serializers

--- a/server/src/main/kotlin/org/kryptonmc/krypton/serializers/ComponentSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/serializers/ComponentSerializer.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.serializers
 
 import kotlinx.serialization.KSerializer

--- a/server/src/main/kotlin/org/kryptonmc/krypton/serializers/UUIDSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/serializers/UUIDSerializer.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.serializers

--- a/server/src/main/kotlin/org/kryptonmc/krypton/serializers/UUIDSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/serializers/UUIDSerializer.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.serializers
 
 import kotlinx.serialization.KSerializer

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/KryptonConfig.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/KryptonConfig.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.server
 
 import kotlinx.serialization.KSerializer

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/KryptonConfig.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/KryptonConfig.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.server

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/ANSITextPane.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/ANSITextPane.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.server.gui
 
 import java.awt.Color

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/ANSITextPane.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/ANSITextPane.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.server.gui

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/KryptonServerGUI.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/KryptonServerGUI.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.server.gui
 
 import org.kryptonmc.krypton.KryptonServer

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/KryptonServerGUI.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/KryptonServerGUI.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.server.gui

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/PlayerListComponent.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/PlayerListComponent.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.server.gui
 
 import org.kryptonmc.krypton.KryptonServer

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/PlayerListComponent.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/PlayerListComponent.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.server.gui

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/stats/GraphColor.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/stats/GraphColor.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.server.gui.stats
 
 import org.kryptonmc.krypton.util.square

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/stats/GraphColor.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/stats/GraphColor.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.server.gui.stats

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/stats/GraphData.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/stats/GraphData.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.server.gui.stats
 
 data class GraphData(var total: Long, var free: Long, var max: Long) {

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/stats/GraphData.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/stats/GraphData.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.server.gui.stats

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/stats/GuiStatsComponent.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/stats/GuiStatsComponent.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.server.gui.stats

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/stats/GuiStatsComponent.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/stats/GuiStatsComponent.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.server.gui.stats
 
 import org.kryptonmc.krypton.KryptonServer

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/stats/RAMDetails.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/stats/RAMDetails.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.server.gui.stats

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/stats/RAMDetails.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/stats/RAMDetails.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.server.gui.stats
 
 import org.kryptonmc.krypton.KryptonServer

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/stats/RAMGraph.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/stats/RAMGraph.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.server.gui.stats
 
 import java.awt.Color

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/stats/RAMGraph.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/gui/stats/RAMGraph.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.server.gui.stats

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/query/GS4QueryHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/query/GS4QueryHandler.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.server.query
 
 import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/query/GS4QueryHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/query/GS4QueryHandler.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.server.query

--- a/server/src/main/kotlin/org/kryptonmc/krypton/service/KryptonServiceProvider.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/service/KryptonServiceProvider.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.service

--- a/server/src/main/kotlin/org/kryptonmc/krypton/service/KryptonServiceProvider.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/service/KryptonServiceProvider.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.service
 
 import org.kryptonmc.krypton.api.plugin.Plugin

--- a/server/src/main/kotlin/org/kryptonmc/krypton/service/KryptonServicesManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/service/KryptonServicesManager.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.service

--- a/server/src/main/kotlin/org/kryptonmc/krypton/service/KryptonServicesManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/service/KryptonServicesManager.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.service
 
 import org.kryptonmc.krypton.api.plugin.Plugin

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/Angle.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/Angle.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/Angle.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/Angle.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util
 
 /**

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/NetworkDataOutputStream.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/NetworkDataOutputStream.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/NetworkDataOutputStream.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/NetworkDataOutputStream.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util
 
 import java.io.ByteArrayOutputStream

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/QueueLogAppender.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/QueueLogAppender.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util
 
 import org.apache.logging.log4j.core.Filter

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/QueueLogAppender.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/QueueLogAppender.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/Rotation.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/Rotation.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util
 
 // TODO: Look into the actual use of this and see if it can be replaced

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/Rotation.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/Rotation.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/TranslationRegister.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/TranslationRegister.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util
 
 import net.kyori.adventure.key.Key

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/TranslationRegister.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/TranslationRegister.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/bytebufs.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/bytebufs.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/bytebufs.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/bytebufs.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/concurrent/DefaultUncaughtExceptionHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/concurrent/DefaultUncaughtExceptionHandler.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.concurrent

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/concurrent/DefaultUncaughtExceptionHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/concurrent/DefaultUncaughtExceptionHandler.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.concurrent
 
 import org.apache.logging.log4j.Logger

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/concurrent/NamedThreadFactory.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/concurrent/NamedThreadFactory.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.concurrent

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/concurrent/NamedThreadFactory.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/concurrent/NamedThreadFactory.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.concurrent
 
 import java.util.Locale

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/concurrent/NamedUncaughtExceptionHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/concurrent/NamedUncaughtExceptionHandler.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.concurrent

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/concurrent/NamedUncaughtExceptionHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/concurrent/NamedUncaughtExceptionHandler.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.concurrent
 
 import org.apache.logging.log4j.Logger

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/csv/CSVFile.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/csv/CSVFile.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.csv

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/csv/CSVFile.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/csv/CSVFile.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.csv
 
 import java.io.Writer

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/csv/csvDSL.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/csv/csvDSL.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.csv

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/csv/csvDSL.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/csv/csvDSL.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.csv
 
 import java.io.Writer

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/csv/csvEscaping.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/csv/csvEscaping.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.csv
 
 import java.io.StringWriter

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/csv/csvEscaping.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/csv/csvEscaping.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.csv

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/encryption/Encryption.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/encryption/Encryption.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.encryption

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/encryption/Encryption.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/encryption/Encryption.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.encryption
 
 import java.security.KeyPair

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/encryption/cryptography.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/encryption/cryptography.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.encryption
 
 import java.math.BigInteger

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/encryption/cryptography.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/encryption/cryptography.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.encryption

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/io.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/io.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util
 
 import java.io.InputStream

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/io.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/io.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/locations.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/locations.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util
 
 import org.kryptonmc.krypton.api.space.Position

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/locations.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/locations.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/maths.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/maths.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util
 
 import org.kryptonmc.krypton.world.chunk.ChunkPosition

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/maths.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/maths.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/metadata.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/metadata.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/metadata.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/metadata.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/monitoring/jmx/KryptonStatistics.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/monitoring/jmx/KryptonStatistics.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.monitoring.jmx
 
 import org.kryptonmc.krypton.KryptonServer

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/monitoring/jmx/KryptonStatistics.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/monitoring/jmx/KryptonStatistics.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.monitoring.jmx

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/CollectibleProfiler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/CollectibleProfiler.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.profiling
 
 import org.kryptonmc.krypton.util.profiling.results.ProfileResults

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/CollectibleProfiler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/CollectibleProfiler.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.profiling

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/DeadProfiler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/DeadProfiler.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.profiling
 
 import org.kryptonmc.krypton.util.profiling.results.EmptyProfileResults

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/DeadProfiler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/DeadProfiler.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.profiling

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/LiveProfiler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/LiveProfiler.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.profiling
 
 import it.unimi.dsi.fastutil.longs.LongArrayList

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/LiveProfiler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/LiveProfiler.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.profiling

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/Profiler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/Profiler.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.profiling
 
 interface Profiler {

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/Profiler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/Profiler.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.profiling

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/ServerProfiler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/ServerProfiler.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.profiling
 
 import org.kryptonmc.krypton.util.profiling.results.ProfileResults

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/ServerProfiler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/ServerProfiler.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.profiling

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/SingleTickProfiler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/SingleTickProfiler.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.profiling
 
 import org.kryptonmc.krypton.util.logger

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/SingleTickProfiler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/SingleTickProfiler.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.profiling

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/entry/EmptyPathEntry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/entry/EmptyPathEntry.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.profiling.entry
 
 import it.unimi.dsi.fastutil.objects.Object2LongMap

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/entry/EmptyPathEntry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/entry/EmptyPathEntry.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.profiling.entry

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/entry/PathEntry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/entry/PathEntry.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.profiling.entry
 
 import it.unimi.dsi.fastutil.objects.Object2LongMap

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/entry/PathEntry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/entry/PathEntry.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.profiling.entry

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/results/EmptyProfileResults.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/results/EmptyProfileResults.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.profiling.results
 
 import java.nio.file.Path

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/results/EmptyProfileResults.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/results/EmptyProfileResults.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.profiling.results

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/results/FilledProfileResults.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/results/FilledProfileResults.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.profiling.results

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/results/FilledProfileResults.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/results/FilledProfileResults.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.profiling.results
 
 import org.kryptonmc.krypton.KryptonServer.KryptonServerInfo

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/results/ProfileResults.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/results/ProfileResults.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.profiling.results
 
 import java.nio.file.Path

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/results/ProfileResults.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/results/ProfileResults.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.profiling.results

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/results/ResultField.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/results/ResultField.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.profiling.results
 
 data class ResultField(

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/results/ResultField.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/profiling/results/ResultField.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.profiling.results

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/thread/GenericThread.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/thread/GenericThread.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util.thread

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/thread/GenericThread.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/thread/GenericThread.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.thread
 
 import org.kryptonmc.krypton.util.concurrent.DefaultUncaughtExceptionHandler

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/utils.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/utils.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util
 
 import org.apache.logging.log4j.LogManager

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/utils.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/utils.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.util

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/Gamerule.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/Gamerule.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world
 
 import net.kyori.adventure.util.Index

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/Gamerule.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/Gamerule.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/Heightmap.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/Heightmap.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world
 
 import net.kyori.adventure.nbt.LongArrayBinaryTag

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/Heightmap.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/Heightmap.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/KryptonWorld.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/KryptonWorld.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world
 
 import net.kyori.adventure.bossbar.BossBar

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/KryptonWorld.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/KryptonWorld.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/KryptonWorldBorder.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/KryptonWorldBorder.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world
 
 import org.kryptonmc.krypton.api.world.Location

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/KryptonWorldBorder.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/KryptonWorldBorder.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/KryptonWorldManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/KryptonWorldManager.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world
 
 import net.kyori.adventure.bossbar.BossBar

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/KryptonWorldManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/KryptonWorldManager.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/LocationBuilder.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/LocationBuilder.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world
 
 /**

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/LocationBuilder.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/LocationBuilder.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/block/BlockFace.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/block/BlockFace.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.block

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/block/BlockFace.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/block/BlockFace.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.block
 
 import net.kyori.adventure.util.Index

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/block/KryptonBlock.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/block/KryptonBlock.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.block

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/block/KryptonBlock.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/block/KryptonBlock.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.block
 
 import org.kryptonmc.krypton.api.block.Block

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/block/blocks/Banner.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/block/blocks/Banner.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.block.blocks

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/block/blocks/Banner.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/block/blocks/Banner.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.block.blocks
 
 import net.kyori.adventure.nbt.CompoundBinaryTag

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/block/palette/GlobalPalette.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/block/palette/GlobalPalette.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.block.palette

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/block/palette/GlobalPalette.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/block/palette/GlobalPalette.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.block.palette
 
 import kotlinx.serialization.decodeFromString

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/block/tile/BlockEntity.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/block/tile/BlockEntity.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.block.tile
 
 import net.kyori.adventure.nbt.CompoundBinaryTag

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/block/tile/BlockEntity.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/block/tile/BlockEntity.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.block.tile

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/bossbar/Bossbar.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/bossbar/Bossbar.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.bossbar

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/bossbar/Bossbar.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/bossbar/Bossbar.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.bossbar
 
 import net.kyori.adventure.bossbar.BossBar

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/chunk/ChunkManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/chunk/ChunkManager.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.chunk

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/chunk/ChunkManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/chunk/ChunkManager.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.chunk
 
 import com.github.benmanes.caffeine.cache.Cache

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/chunk/ChunkPosition.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/chunk/ChunkPosition.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.chunk
 
 import org.kryptonmc.krypton.api.world.Location

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/chunk/ChunkPosition.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/chunk/ChunkPosition.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.chunk

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/chunk/ChunkSection.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/chunk/ChunkSection.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.chunk

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/chunk/ChunkSection.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/chunk/ChunkSection.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.chunk
 
 import org.kryptonmc.krypton.api.block.Block

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/chunk/KryptonChunk.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/chunk/KryptonChunk.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.chunk
 
 import net.kyori.adventure.nbt.CompoundBinaryTag

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/chunk/KryptonChunk.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/chunk/KryptonChunk.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.chunk

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/data/BitStorage.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/data/BitStorage.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.data

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/data/BitStorage.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/data/BitStorage.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.data
 
 /**

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/data/PlayerDataManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/data/PlayerDataManager.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.data
 
 import net.kyori.adventure.nbt.BinaryTagIO

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/data/PlayerDataManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/data/PlayerDataManager.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.data

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/dimension/Dimension.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/dimension/Dimension.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.dimension
 
 import net.kyori.adventure.nbt.CompoundBinaryTag

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/dimension/Dimension.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/dimension/Dimension.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.dimension

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/dimension/EndDimensionData.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/dimension/EndDimensionData.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.dimension

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/dimension/EndDimensionData.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/dimension/EndDimensionData.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.dimension
 
 import org.kryptonmc.krypton.api.space.Vector

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/FlatGenerator.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/FlatGenerator.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.generation

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/FlatGenerator.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/FlatGenerator.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.generation
 
 import net.kyori.adventure.nbt.BinaryTagTypes

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/Generator.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/Generator.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.generation

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/Generator.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/Generator.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.generation
 
 import net.kyori.adventure.nbt.CompoundBinaryTag

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/GeneratorSettings.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/GeneratorSettings.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.generation

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/GeneratorSettings.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/GeneratorSettings.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.generation
 
 import net.kyori.adventure.nbt.CompoundBinaryTag

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/NoiseGenerator.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/NoiseGenerator.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.generation

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/NoiseGenerator.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/NoiseGenerator.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.generation
 
 import net.kyori.adventure.nbt.BinaryTagTypes

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/WorldGenerationSettings.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/WorldGenerationSettings.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.generation

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/WorldGenerationSettings.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/WorldGenerationSettings.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.generation
 
 import org.kryptonmc.krypton.api.registry.NamespacedKey

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/WorldGenerationStatus.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/WorldGenerationStatus.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.generation

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/WorldGenerationStatus.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/generation/WorldGenerationStatus.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.generation
 
 enum class WorldGenerationStatus {

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/region/RegionFile.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/region/RegionFile.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.region
 
 import org.kryptonmc.krypton.util.createTempFile

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/region/RegionFile.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/region/RegionFile.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.region

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/region/RegionFileCompression.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/region/RegionFileCompression.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.region

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/region/RegionFileCompression.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/region/RegionFileCompression.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.region
 
 import java.io.InputStream

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/region/RegionFileManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/region/RegionFileManager.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.region

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/region/RegionFileManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/region/RegionFileManager.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.region
 
 import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/scoreboard/KryptonScoreboard.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/scoreboard/KryptonScoreboard.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.scoreboard

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/scoreboard/KryptonScoreboard.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/scoreboard/KryptonScoreboard.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.scoreboard
 
 import org.kryptonmc.krypton.api.entity.entities.Player

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/structure/Mineshaft.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/structure/Mineshaft.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.structure

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/structure/Mineshaft.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/structure/Mineshaft.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.structure
 
 import org.kryptonmc.krypton.api.block.BoundingBox

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/structure/Stronghold.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/structure/Stronghold.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.structure

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/structure/Stronghold.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/structure/Stronghold.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.structure
 
 import org.kryptonmc.krypton.api.block.BoundingBox

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/structure/StructureData.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/structure/StructureData.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.structure

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/structure/StructureData.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/structure/StructureData.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.structure
 
 import org.kryptonmc.krypton.api.block.BoundingBox

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/structure/StructureType.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/structure/StructureType.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton.world.structure

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/structure/StructureType.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/structure/StructureType.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.structure
 
 import org.kryptonmc.krypton.api.world.Biome

--- a/server/src/main/resources/log4j2.xml
+++ b/server/src/main/resources/log4j2.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+
+    Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
 <Configuration xmlns="http://logging.apache.org/log4j/2.0/config" status="DEBUG" packages="org.kryptonmc.krypton.util" shutdownHook="disable">
     <Appenders>
         <TerminalConsole name="CONSOLE">

--- a/server/src/main/resources/log4j2.xml
+++ b/server/src/main/resources/log4j2.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-    This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+    This file is part of the Krypton project, licensed under the GNU General Public License v3.0
 
     Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation, either version 3 of the License, or
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+    GNU General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
+    You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <Configuration xmlns="http://logging.apache.org/log4j/2.0/config" status="DEBUG" packages="org.kryptonmc.krypton.util" shutdownHook="disable">

--- a/server/src/test/kotlin/org/kryptonmc/krypton/ArgumentTests.kt
+++ b/server/src/test/kotlin/org/kryptonmc/krypton/ArgumentTests.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton

--- a/server/src/test/kotlin/org/kryptonmc/krypton/ArgumentTests.kt
+++ b/server/src/test/kotlin/org/kryptonmc/krypton/ArgumentTests.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton
 
 import com.mojang.brigadier.StringReader

--- a/server/src/test/kotlin/org/kryptonmc/krypton/AuthenticationTests.kt
+++ b/server/src/test/kotlin/org/kryptonmc/krypton/AuthenticationTests.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton
 
 import org.kryptonmc.krypton.auth.GameProfile

--- a/server/src/test/kotlin/org/kryptonmc/krypton/AuthenticationTests.kt
+++ b/server/src/test/kotlin/org/kryptonmc/krypton/AuthenticationTests.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton

--- a/server/src/test/kotlin/org/kryptonmc/krypton/CommandTests.kt
+++ b/server/src/test/kotlin/org/kryptonmc/krypton/CommandTests.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton
 
 import com.mojang.brigadier.arguments.LongArgumentType

--- a/server/src/test/kotlin/org/kryptonmc/krypton/CommandTests.kt
+++ b/server/src/test/kotlin/org/kryptonmc/krypton/CommandTests.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton

--- a/server/src/test/kotlin/org/kryptonmc/krypton/ConfigTests.kt
+++ b/server/src/test/kotlin/org/kryptonmc/krypton/ConfigTests.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton

--- a/server/src/test/kotlin/org/kryptonmc/krypton/ConfigTests.kt
+++ b/server/src/test/kotlin/org/kryptonmc/krypton/ConfigTests.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton
 
 import com.typesafe.config.ConfigFactory

--- a/server/src/test/kotlin/org/kryptonmc/krypton/SenderTests.kt
+++ b/server/src/test/kotlin/org/kryptonmc/krypton/SenderTests.kt
@@ -1,19 +1,19 @@
 /*
- * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
  *
  * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.kryptonmc.krypton

--- a/server/src/test/kotlin/org/kryptonmc/krypton/SenderTests.kt
+++ b/server/src/test/kotlin/org/kryptonmc/krypton/SenderTests.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton
 
 import io.mockk.every


### PR DESCRIPTION
As you can tell by the title, I have decided to relicense Krypton under the terms of the GNU Lesser General Public License v3.0.

The primary reason for this change is that I believe it will better benefit the project, and that it closer agrees with my values, in that I would much rather not see my hours and hours of hard work and effort be rebranded and sold on by someone who has contributed nothing to the project. These what I will call here "leechers" are sins to the open-source world, and I want to avoid this happening to this project.

If you are one of the contributors to this project (@knightzmc , @Esophose and @PulseBeat02 ), and you would not mind me relicensing your contributions under the terms of the GNU Lesser General Public License, please do so by making it clear in writing that you are in fact okay with this. Something as simple as "I give you my explicit permission to re-license my contributed code under the terms of the GNU Lesser General Public License 3.0" is satisfactory for this.

Just to be explicitly clear, only the server side of Krypton is being relicensed. The API will remain under the same MIT license, with the addition of license headers.