### PR TITLE
Localisation for the entire server

### DIFF
--- a/api/src/main/kotlin/org/kryptonmc/api/util/keys.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/util/keys.kt
@@ -1,3 +1,11 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
 package org.kryptonmc.api.util
 
 import net.kyori.adventure.key.Key

--- a/server/src/main/kotlin/org/kryptonmc/krypton/Metrics.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/Metrics.kt
@@ -26,6 +26,7 @@ import org.bstats.charts.SimplePie
 import org.bstats.charts.SingleLineChart
 import org.bstats.config.MetricsConfig
 import org.bstats.json.JsonObjectBuilder
+import org.kryptonmc.krypton.locale.Messages
 import org.kryptonmc.krypton.util.logger
 import java.io.IOException
 import java.nio.file.Path
@@ -58,13 +59,7 @@ class Metrics(logger: Logger, serviceId: Int, enabled: Boolean) {
             config.isLogResponseStatusTextEnabled
         )
 
-        if (!config.didExistBefore()) {
-            logger.info("Krypton and some of its plugins collect metrics and send them to bStats (https://bstats.org).")
-            logger.info("bStats collects some basic information for plugin authors, like how many people use")
-            logger.info("their plugin and their total player count. It's recommended to keep bStats enabled, but")
-            logger.info("if you're not comfortable with this, you can opt-out by editing the config.txt file in")
-            logger.info("the '/plugins/bStats/' folder and setting enabled to false.")
-        }
+        if (!config.didExistBefore()) Messages.METRICS_INFO.info(logger)
     }
 
     operator fun plusAssign(chart: CustomChart) {

--- a/server/src/main/kotlin/org/kryptonmc/krypton/NettyProcess.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/NettyProcess.kt
@@ -38,6 +38,7 @@ import io.netty.incubator.channel.uring.IOUringEventLoopGroup
 import io.netty.incubator.channel.uring.IOUringServerSocketChannel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.kryptonmc.krypton.locale.Messages
 import org.kryptonmc.krypton.packet.ChannelHandler
 import org.kryptonmc.krypton.packet.transformers.LegacyQueryHandler
 import org.kryptonmc.krypton.packet.transformers.PacketDecoder
@@ -83,9 +84,7 @@ class NettyProcess(private val server: KryptonServer) {
             }
         } catch (exception: IOException) {
             LOGGER.error("-------------------------------------------------")
-            LOGGER.error("FAILED TO BIND TO PORT ${server.config.server.port}!")
-            LOGGER.error("Exception: $exception")
-            LOGGER.error("Perhaps a server is already running on that port?")
+            Messages.ERROR_BIND.info(LOGGER, server.config.server.port, exception)
             LOGGER.error("-------------------------------------------------")
             server.stop()
         } finally {

--- a/server/src/main/kotlin/org/kryptonmc/krypton/adventure/AdventureMessage.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/adventure/AdventureMessage.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.adventure
 
 import com.mojang.brigadier.Message

--- a/server/src/main/kotlin/org/kryptonmc/krypton/auth/requests/MojangSessionService.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/auth/requests/MojangSessionService.kt
@@ -24,6 +24,7 @@ import org.kryptonmc.krypton.GSON
 import org.kryptonmc.krypton.ServerInfo
 import org.kryptonmc.krypton.auth.GameProfile
 import org.kryptonmc.krypton.auth.exceptions.AuthenticationException
+import org.kryptonmc.krypton.locale.Messages
 import org.kryptonmc.krypton.util.encryption.Encryption
 import org.kryptonmc.krypton.util.encryption.hexDigest
 import org.kryptonmc.krypton.util.logger
@@ -105,12 +106,12 @@ object SessionService {
         val response = sessionService.hasJoined(username, serverId, ip).execute()
         if (!response.isSuccessful) {
             LOGGER.debug("Error authenticating $username! Code: ${response.code()}, body: ${response.errorBody()}")
-            LOGGER.error("Failed to verify username $username!")
+            Messages.AUTH.FAIL.error(LOGGER, username)
             throw AuthenticationException()
         }
 
         val profile = requireNotNull(response.body())
-        LOGGER.info("UUID of player ${profile.name} is ${profile.uuid}")
+        Messages.AUTH.SUCCESS.info(LOGGER, profile.name, profile.uuid)
         profiles.put(profile.name, profile)
         return profile
     }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/KryptonCommandManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/KryptonCommandManager.kt
@@ -43,6 +43,7 @@ import org.kryptonmc.krypton.command.commands.DebugCommand
 import org.kryptonmc.krypton.command.commands.RestartCommand
 import org.kryptonmc.krypton.command.commands.StopCommand
 import org.kryptonmc.krypton.command.commands.TeleportCommand
+import org.kryptonmc.krypton.locale.Messages
 import java.util.concurrent.CompletableFuture
 
 class KryptonCommandManager(private val server: KryptonServer) : CommandManager {
@@ -73,7 +74,7 @@ class KryptonCommandManager(private val server: KryptonServer) : CommandManager 
             if (dispatcher.execute(command.removePrefix("/"), sender) != 1) sender.sendMessage(DEFAULT_NO_PERMISSION)
         } catch (exception: CommandSyntaxException) {
             val message = when (exception) {
-                BUILT_IN_EXCEPTIONS.dispatcherUnknownCommand() -> text("Unknown command $command.")
+                BUILT_IN_EXCEPTIONS.dispatcherUnknownCommand() -> Messages.COMMAND.UNKNOWN(command)
                 else -> text(exception.message ?: "")
             }
             sender.sendMessage(message)
@@ -154,6 +155,6 @@ class KryptonCommandManager(private val server: KryptonServer) : CommandManager 
 
     companion object {
 
-        private val DEFAULT_NO_PERMISSION = text("You do not have permission to execute this command!", NamedTextColor.RED)
+        private val DEFAULT_NO_PERMISSION = Messages.COMMAND.NO_PERMISSION().color(NamedTextColor.RED)
     }
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/VectorArgument.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/VectorArgument.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command.arguments
 
 import com.mojang.brigadier.StringReader

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/coordinates/Coordinates.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/coordinates/Coordinates.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command.arguments.coordinates
 
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/coordinates/LocalCoordinates.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/coordinates/LocalCoordinates.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command.arguments.coordinates
 
 import com.mojang.brigadier.StringReader

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/coordinates/WorldCoordinates.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/coordinates/WorldCoordinates.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command.arguments.coordinates
 
 import com.mojang.brigadier.StringReader

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/DebugCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/DebugCommand.kt
@@ -28,6 +28,7 @@ import org.kryptonmc.krypton.KryptonServer
 import org.kryptonmc.krypton.adventure.toMessage
 import org.kryptonmc.api.command.Sender
 import org.kryptonmc.krypton.command.BrigadierCommand
+import org.kryptonmc.krypton.locale.Messages
 import org.kryptonmc.krypton.util.createDirectories
 import org.kryptonmc.krypton.util.logger
 import java.io.IOException
@@ -81,7 +82,7 @@ class DebugCommand(private val server: KryptonServer) : BrigadierCommand {
             }
             sender.sendMessage(translatable("commands.debug.reportSaved", listOf(text(reportFileName))))
         } catch (exception: IOException) {
-            LOGGER.error("Failed to save debug dump!", exception)
+            Messages.COMMANDS.DEBUG_SAVE_ERROR.error(LOGGER, exception)
             sender.sendMessage(translatable("commands.debug.reportFailed"))
         }
     }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/RestartCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/RestartCommand.kt
@@ -18,15 +18,15 @@
  */
 package org.kryptonmc.krypton.command.commands
 
-import net.kyori.adventure.text.Component
 import org.kryptonmc.krypton.KryptonServer
 import org.kryptonmc.api.command.Command
 import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.locale.Messages
 
 class RestartCommand(private val server: KryptonServer) : Command("restart", "krypton.command.restart") {
 
     override fun execute(sender: Sender, args: List<String>) {
-        sender.sendMessage(Component.text("Attempting to restart the server..."))
+        Messages.COMMANDS.RESTART.send(sender)
         server.restart()
     }
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/StopCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/StopCommand.kt
@@ -18,10 +18,10 @@
  */
 package org.kryptonmc.krypton.command.commands
 
-import net.kyori.adventure.text.Component
 import org.kryptonmc.krypton.KryptonServer
 import org.kryptonmc.api.command.Command
 import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.locale.Messages
 
 /**
  * Stop the server. That's literally all this does
@@ -29,7 +29,7 @@ import org.kryptonmc.api.command.Sender
 class StopCommand(private val server: KryptonServer) : Command("stop", "krypton.command.stop") {
 
     override fun execute(sender: Sender, args: List<String>) {
-        sender.sendMessage(Component.text("Stopping server..."))
+        Messages.COMMANDS.STOP.send(sender)
         server.stop()
     }
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/TeleportCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/TeleportCommand.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command.commands
 
 import com.mojang.brigadier.CommandDispatcher

--- a/server/src/main/kotlin/org/kryptonmc/krypton/config/KryptonConfig.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/config/KryptonConfig.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.config
 
 import net.kyori.adventure.serializer.configurate4.ConfigurateComponentSerializer

--- a/server/src/main/kotlin/org/kryptonmc/krypton/config/KryptonConfig.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/config/KryptonConfig.kt
@@ -11,6 +11,7 @@ import org.kryptonmc.krypton.config.category.WatchdogCategory
 import org.kryptonmc.krypton.config.category.WorldCategory
 import org.kryptonmc.krypton.config.serializer.DifficultyTypeSerializer
 import org.kryptonmc.krypton.config.serializer.GamemodeTypeSerializer
+import org.kryptonmc.krypton.config.serializer.LocaleTypeSerializer
 import org.spongepowered.configurate.ConfigurationOptions
 import org.spongepowered.configurate.kotlin.objectMapperFactory
 import org.spongepowered.configurate.objectmapping.ConfigSerializable
@@ -59,6 +60,7 @@ data class KryptonConfig(
                     .serializers()
                 ).register(DifficultyTypeSerializer)
                     .register(GamemodeTypeSerializer)
+                    .register(LocaleTypeSerializer)
                     .registerAnnotatedObjects(objectMapperFactory())
             }
     }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/config/category/AdvancedCategory.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/config/category/AdvancedCategory.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.config.category
 
 import org.spongepowered.configurate.objectmapping.ConfigSerializable

--- a/server/src/main/kotlin/org/kryptonmc/krypton/config/category/OtherCategory.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/config/category/OtherCategory.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.config.category
 
 import org.spongepowered.configurate.objectmapping.ConfigSerializable

--- a/server/src/main/kotlin/org/kryptonmc/krypton/config/category/QueryCategory.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/config/category/QueryCategory.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.config.category
 
 import org.spongepowered.configurate.objectmapping.ConfigSerializable

--- a/server/src/main/kotlin/org/kryptonmc/krypton/config/category/ServerCategory.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/config/category/ServerCategory.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.config.category
 
 import org.spongepowered.configurate.objectmapping.ConfigSerializable

--- a/server/src/main/kotlin/org/kryptonmc/krypton/config/category/StatusCategory.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/config/category/StatusCategory.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.config.category
 
 import net.kyori.adventure.text.Component

--- a/server/src/main/kotlin/org/kryptonmc/krypton/config/category/WatchdogCategory.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/config/category/WatchdogCategory.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.config.category
 
 import net.kyori.adventure.text.Component

--- a/server/src/main/kotlin/org/kryptonmc/krypton/config/category/WorldCategory.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/config/category/WorldCategory.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.config.category
 
 import org.kryptonmc.api.world.Difficulty

--- a/server/src/main/kotlin/org/kryptonmc/krypton/config/serializer/DifficultyTypeSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/config/serializer/DifficultyTypeSerializer.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.config.serializer
 
 import org.kryptonmc.api.world.Difficulty

--- a/server/src/main/kotlin/org/kryptonmc/krypton/config/serializer/GamemodeTypeSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/config/serializer/GamemodeTypeSerializer.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.config.serializer
 
 import org.kryptonmc.api.world.Gamemode

--- a/server/src/main/kotlin/org/kryptonmc/krypton/config/serializer/LocaleTypeSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/config/serializer/LocaleTypeSerializer.kt
@@ -1,0 +1,21 @@
+package org.kryptonmc.krypton.config.serializer
+
+import org.spongepowered.configurate.serialize.ScalarSerializer
+import org.spongepowered.configurate.serialize.SerializationException
+import java.lang.reflect.Type
+import java.util.Locale
+import java.util.function.Predicate
+
+object LocaleTypeSerializer : ScalarSerializer<Locale>(Locale::class.java) {
+
+    override fun serialize(item: Locale, typeSupported: Predicate<Class<*>>) = item.toString()
+
+    override fun deserialize(type: Type, obj: Any): Locale {
+        if (obj !is String) throw SerializationException("Locale must be a string!")
+        val split = obj.split("[_-]".toRegex())
+        if (split.isEmpty()) throw SerializationException("Locale cannot be empty!")
+        if (split.size == 1) return Locale(split[0])
+        if (split.size == 2) return Locale(split[0], split[1])
+        throw SerializationException("Cannot deserialize $obj into a valid locale!")
+    }
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/config/serializer/LocaleTypeSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/config/serializer/LocaleTypeSerializer.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.config.serializer
 
 import org.spongepowered.configurate.serialize.ScalarSerializer

--- a/server/src/main/kotlin/org/kryptonmc/krypton/event/KryptonEventBus.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/event/KryptonEventBus.kt
@@ -21,6 +21,7 @@ package org.kryptonmc.krypton.event
 import com.google.common.collect.Multimaps
 import org.kryptonmc.api.event.EventBus
 import org.kryptonmc.api.event.Listener
+import org.kryptonmc.krypton.locale.Messages
 import org.kryptonmc.krypton.util.logger
 import java.lang.reflect.Method
 import java.util.concurrent.ConcurrentHashMap
@@ -60,7 +61,7 @@ object KryptonEventBus : EventBus {
 
             val parameters = it.parameterTypes
             if (parameters.size != 1) {
-                LOGGER.warn("Method $it in class ${listener::class.java} annotated with $annotation does not have a single argument!")
+                Messages.EVENT_SINGLE_ARGUMENT.warn(LOGGER, it, listener::class.java, annotation)
                 return@forEach
             }
 

--- a/server/src/main/kotlin/org/kryptonmc/krypton/locale/Messages.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/locale/Messages.kt
@@ -1,0 +1,641 @@
+package org.kryptonmc.krypton.locale
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.Component.translatable
+import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.Logger
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.api.event.Listener
+import org.kryptonmc.krypton.world.block.KryptonBlock
+import org.kryptonmc.krypton.world.chunk.ChunkPosition
+import java.io.IOException
+import java.lang.reflect.Method
+import java.nio.file.Path
+import java.util.UUID
+
+object Messages {
+
+    // Krypton version {0} for Minecraft {1}
+    val VERSION_INFO = doubleText("krypton.version-info")
+
+    val START = StartMessages
+    val AUTOSAVE = AutosaveMessages
+    val STOP = StopMessages
+    val WATCHDOG = WatchdogMessages
+    val RESTART = RestartMessages
+    val WORLD = WorldMessages
+    val REGION = RegionMessages
+    val AUTH = AuthMessages
+    val COMMAND = CommandMessages
+    val COMMANDS = CommandsMessages
+    val BUNGEE = BungeeMessages
+    val NETWORK = NetworkMessages
+    val PLUGIN = PluginMessages
+    val GUI = GUIMessages
+    val QUERY = QueryMessages
+    val JMX = JMXMessages
+    val PROFILER = ProfilerMessages
+    val THREAD = ThreadMessages
+
+    // Starting Krypton server version {0} for Minecraft {1}
+    val LOAD = doubleText("load")
+    // You're starting the server with {0} megabytes of RAM.
+    // Consider starting it with more by using \"java -Xmx1024M -Xms1024M -jar Krypton-{1}.jar\" to start it with 1 GB RAM.
+    val LOAD_LOW_MEMORY = doubleText("load.low-memory")
+
+    // FAILED TO BIND TO PORT {0}
+    // Exception: {1}
+    // Perhaps a server is already running on that port?
+    val ERROR_BIND = Args2<Int, IOException> { port, exception -> translatable("krypton.error.bind", listOf(text(port), text(exception.toString()))) }
+
+    // SERVER IS IN OFFLINE MODE! THIS SERVER WILL MAKE NO ATTEMPTS TO AUTHENTICATE USERS!
+    // While this may allow players without full Minecraft accounts to connect, it also allows hackers to connect with any username they choose! Beware!
+    // To get rid of this message, change online-mode to true in config.conf
+    val PIRACY_WARNING = empty("piracy-warning")
+
+    // Woah there! Can't keep up! Running {0}ms ({1} ticks) behind!
+    val TICK_OVERLOAD_WARNING = Args2<Long, Long> { ms, ticks -> translatable("krypton.overload-warning", listOf(text(ms), text(ticks))) }
+
+    // Krypton and some of its plugins collect metrics and send them to bStats (https://bstats.org).
+    // bStats collects some basic information for plugin authors, like how many people use
+    // their plugin and their total player count. It's recommended to keep bStats enabled, but
+    // if you're not comfortable with this, you can opt-out by editing the config.txt file in
+    // the '/plugins/bStats/' folder and setting enabled to false.
+    val METRICS_INFO = empty("metrics.info")
+
+    // Attempted to place block {0} under/over the world! The section at {1} cannot be set!
+    val BLOCK_UNDER_WORLD = Args2<KryptonBlock, Int> { block, y -> translatable("krypton.block.under-world", listOf(text(block.toString()), text(y))) }
+
+    // Could not serialise {0} (Class {1})! Will not be sent to client!
+    val ARGUMENT_ERROR = doubleText("argument-error")
+
+    // Method {0} in class {1} annotated with {2} does not have a single argument!
+    val EVENT_SINGLE_ARGUMENT = Args3<Method, Class<*>, Listener> { method, clazz, annotation ->
+        translatable("krypton.event-single-argument", listOf(text(method.name), text(clazz.simpleName), text(annotation.toString())))
+    }
+
+    // Plugin {0} generated an exception from task {1}!
+    val SCHEDULE_ERROR = Args2<String, Runnable> { name, task -> translatable("krypton.schedule-error", listOf(text(name), text(task.toString()))) }
+
+    sealed interface Args {
+
+        fun send(sender: Sender, component: Component) = sender.sendMessage(component)
+
+        fun print(component: Component) {
+            val translated = TranslationManager.render(component)
+            if (translated is TextComponent) translated.content().split("\n").forEach { println(it) }
+        }
+
+        fun log(logger: Logger, level: Level, component: Component) {
+            val serialized = LegacyComponentSerializer.legacySection().serialize(TranslationManager.render(component))
+            val split = serialized.split("\n")
+            if (split.isNotEmpty()) return split.forEach { logger.log(level, it) }
+            logger.log(level, serialized)
+        }
+
+        fun log(logger: Logger, level: Level, component: Component, exception: Throwable) {
+            val serialized = LegacyComponentSerializer.legacySection().serialize(TranslationManager.render(component))
+            logger.log(level, serialized, exception)
+        }
+
+        fun info(logger: Logger, component: Component) = log(logger, Level.INFO, component)
+        fun warn(logger: Logger, component: Component) = log(logger, Level.WARN, component)
+        fun error(logger: Logger, component: Component) = log(logger, Level.ERROR, component)
+        fun error(logger: Logger, component: Component, exception: Throwable) = log(logger, Level.ERROR, component, exception)
+        fun fatal(logger: Logger, component: Component) = log(logger, Level.FATAL, component)
+        fun fatal(logger: Logger, component: Component, exception: Throwable) = log(logger, Level.FATAL, component, exception)
+    }
+
+    fun interface Args0 : () -> Component, Args {
+
+        fun send(sender: Sender) = send(sender, this())
+        fun print() = print(this())
+        fun info(logger: Logger) = info(logger, this())
+        fun warn(logger: Logger) = warn(logger, this())
+        fun error(logger: Logger) = error(logger, this())
+        fun error(logger: Logger, exception: Throwable) = error(logger, this(), exception)
+        fun fatal(logger: Logger) = fatal(logger, this())
+        fun fatal(logger: Logger, exception: Throwable) = fatal(logger, this(), exception)
+    }
+
+    fun interface Args1<A> : (A) -> Component, Args {
+
+        fun send(sender: Sender, arg1: A) = send(sender, this(arg1))
+        fun print(arg1: A) = print(this(arg1))
+        fun info(logger: Logger, arg1: A) = info(logger, this(arg1))
+        fun warn(logger: Logger, arg1: A) = warn(logger, this(arg1))
+        fun error(logger: Logger, arg1: A) = error(logger, this(arg1))
+        fun error(logger: Logger, arg1: A, exception: Throwable) = error(logger, this(arg1), exception)
+        fun fatal(logger: Logger, arg1: A) = fatal(logger, this(arg1))
+        fun fatal(logger: Logger, arg1: A, exception: Throwable) = fatal(logger, this(arg1), exception)
+    }
+
+    fun interface Args2<A, B> : (A, B) -> Component, Args {
+
+        fun send(sender: Sender, arg1: A, arg2: B) = send(sender, this(arg1, arg2))
+        fun print(arg1: A, arg2: B) = print(this(arg1, arg2))
+        fun info(logger: Logger, arg1: A, arg2: B) = info(logger, this(arg1, arg2))
+        fun warn(logger: Logger, arg1: A, arg2: B) = warn(logger, this(arg1, arg2))
+        fun error(logger: Logger, arg1: A, arg2: B) = error(logger, this(arg1, arg2))
+        fun error(logger: Logger, arg1: A, arg2: B, exception: Throwable) = error(logger, this(arg1, arg2), exception)
+        fun fatal(logger: Logger, arg1: A, arg2: B) = fatal(logger, this(arg1, arg2))
+        fun fatal(logger: Logger, arg1: A, arg2: B, exception: Throwable) = fatal(logger, this(arg1, arg2), exception)
+    }
+
+    fun interface Args3<A, B, C> : (A, B, C) -> Component, Args {
+
+        fun send(sender: Sender, arg1: A, arg2: B, arg3: C) = send(sender, this(arg1, arg2, arg3))
+        fun print(arg1: A, arg2: B, arg3: C) = print(this(arg1, arg2, arg3))
+        fun info(logger: Logger, arg1: A, arg2: B, arg3: C) = info(logger, this(arg1, arg2, arg3))
+        fun warn(logger: Logger, arg1: A, arg2: B, arg3: C) = warn(logger, this(arg1, arg2, arg3))
+        fun error(logger: Logger, arg1: A, arg2: B, arg3: C) = error(logger, this(arg1, arg2, arg3))
+        fun error(logger: Logger, arg1: A, arg2: B, arg3: C, exception: Throwable) = error(logger, this(arg1, arg2, arg3), exception)
+        fun fatal(logger: Logger, arg1: A, arg2: B, arg3: C) = fatal(logger, this(arg1, arg2, arg3))
+        fun fatal(logger: Logger, arg1: A, arg2: B, arg3: C, exception: Throwable) = fatal(logger, this(arg1, arg2, arg3), exception)
+    }
+
+    fun interface Args4<A, B, C, D> : (A, B, C, D) -> Component, Args {
+
+        fun send(sender: Sender, arg1: A, arg2: B, arg3: C, arg4: D) = send(sender, this(arg1, arg2, arg3, arg4))
+        fun print(arg1: A, arg2: B, arg3: C, arg4: D) = print(this(arg1, arg2, arg3, arg4))
+        fun info(logger: Logger, arg1: A, arg2: B, arg3: C, arg4: D) = info(logger, this(arg1, arg2, arg3, arg4))
+        fun warn(logger: Logger, arg1: A, arg2: B, arg3: C, arg4: D) = warn(logger, this(arg1, arg2, arg3, arg4))
+        fun error(logger: Logger, arg1: A, arg2: B, arg3: C, arg4: D) = error(logger, this(arg1, arg2, arg3, arg4))
+        fun error(logger: Logger, arg1: A, arg2: B, arg3: C, arg4: D, exception: Throwable) = error(logger, this(arg1, arg2, arg3, arg4), exception)
+        fun fatal(logger: Logger, arg1: A, arg2: B, arg3: C, arg4: D) = fatal(logger, this(arg1, arg2, arg3, arg4))
+        fun fatal(logger: Logger, arg1: A, arg2: B, arg3: C, arg4: D, exception: Throwable) = fatal(logger, this(arg1, arg2, arg3, arg4), exception)
+    }
+
+    fun interface Args5<A, B, C, D, E> : (A, B, C, D, E) -> Component, Args {
+
+        fun send(sender: Sender, arg1: A, arg2: B, arg3: C, arg4: D, arg5: E) = send(sender, this(arg1, arg2, arg3, arg4, arg5))
+        fun print(arg1: A, arg2: B, arg3: C, arg4: D, arg5: E) = print(this(arg1, arg2, arg3, arg4, arg5))
+        fun info(logger: Logger, arg1: A, arg2: B, arg3: C, arg4: D, arg5: E) = info(logger, this(arg1, arg2, arg3, arg4, arg5))
+        fun warn(logger: Logger, arg1: A, arg2: B, arg3: C, arg4: D, arg5: E) = warn(logger, this(arg1, arg2, arg3, arg4, arg5))
+        fun error(logger: Logger, arg1: A, arg2: B, arg3: C, arg4: D, arg5: E) = error(logger, this(arg1, arg2, arg3, arg4, arg5))
+        fun error(logger: Logger, arg1: A, arg2: B, arg3: C, arg4: D, arg5: E, exception: Throwable) = error(logger, this(arg1, arg2, arg3, arg4, arg5), exception)
+        fun fatal(logger: Logger, arg1: A, arg2: B, arg3: C, arg4: D, arg5: E) = fatal(logger, this(arg1, arg2, arg3, arg4, arg5))
+        fun fatal(logger: Logger, arg1: A, arg2: B, arg3: C, arg4: D, arg5: E, exception: Throwable) = fatal(logger, this(arg1, arg2, arg3, arg4, arg5), exception)
+    }
+
+    fun interface Args6<A, B, C, D, E, F> : (A, B, C, D, E, F) -> Component, Args {
+
+        fun send(sender: Sender, arg1: A, arg2: B, arg3: C, arg4: D, arg5: E, arg6: F) = send(sender, this(arg1, arg2, arg3, arg4, arg5, arg6))
+        fun print(arg1: A, arg2: B, arg3: C, arg4: D, arg5: E, arg6: F) = print(this(arg1, arg2, arg3, arg4, arg5, arg6))
+        fun info(logger: Logger, arg1: A, arg2: B, arg3: C, arg4: D, arg5: E, arg6: F) = info(logger, this(arg1, arg2, arg3, arg4, arg5, arg6))
+        fun warn(logger: Logger, arg1: A, arg2: B, arg3: C, arg4: D, arg5: E, arg6: F) = warn(logger, this(arg1, arg2, arg3, arg4, arg5, arg6))
+        fun error(logger: Logger, arg1: A, arg2: B, arg3: C, arg4: D, arg5: E, arg6: F) = error(logger, this(arg1, arg2, arg3, arg4, arg5, arg6))
+        fun error(logger: Logger, arg1: A, arg2: B, arg3: C, arg4: D, arg5: E, arg6: F, exception: Throwable) = error(logger, this(arg1, arg2, arg3, arg4, arg5, arg6), exception)
+        fun fatal(logger: Logger, arg1: A, arg2: B, arg3: C, arg4: D, arg5: E, arg6: F) = fatal(logger, this(arg1, arg2, arg3, arg4, arg5, arg6))
+        fun fatal(logger: Logger, arg1: A, arg2: B, arg3: C, arg4: D, arg5: E, arg6: F, exception: Throwable) = fatal(logger, this(arg1, arg2, arg3, arg4, arg5, arg6), exception)
+    }
+
+    object StartMessages {
+
+        // Starting Krypton server on {0}:{1}...
+        val INITIAL = Args2<String, Int> { ip, port -> translatable("krypton.start", listOf(text(ip), text(port))) }
+
+        // Starting GS4 status listener...
+        val QUERY = empty("start.query")
+
+        // Done ({0})! Type "help" for help.
+        val DONE = singleText("start.done")
+    }
+
+    object AutosaveMessages {
+
+        // Autosave started
+        val STARTED = empty("autosave.started")
+
+        // Autosave finished
+        val FINISHED = empty("autosave.finished")
+    }
+
+    object StopMessages {
+
+        // Stopping Krypton...
+        val INITIAL = empty("stop")
+
+        // Saving player, world and region data...
+        val SAVE = empty("stop.save")
+
+        // Shutting down plugins...
+        val PLUGINS = empty("stop.plugins")
+
+        // Goodbye
+        val GOODBYE = empty("stop.goodbye")
+    }
+
+    object RestartMessages {
+
+        // Attempting to restart the server with script {0}...
+        val ATTEMPT = singleText("restart.attempt")
+
+        // Unable to find restart script {0}! Refusing to restart.
+        val NO_SCRIPT = singleText("restart.no-script")
+    }
+
+    object WatchdogMessages {
+
+        val DUMP = DumpMessages
+
+        // ---- DO NOT REPORT THIS TO KRYPTON! THIS IS NOT A BUG OR CRASH! ----
+        val HEADER = empty("watchdog.header")
+
+        // The server has not responded for {0} seconds! Creating thread dump...
+        val WARNING = Args1<Long> { translatable("krypton.watchdog.warning", listOf(text(it))) }
+
+        // The server has stopped responding! This could be, but is not likely to be, an issue with Krypton.
+        // If you see a plugin in the server thread dump below, then please report it to that author.
+        // \t *Especially* if it looks like HTTP or MySQL operations are occurring
+        // If you see a world save or edit, then it likely means you tried to do much more than your server can handle at once
+        // \t If this is the case, consider increasing timeout-time in the main configuration file. Please note, however, that this will replace this crash with LARGE lag spikes
+        // If you are still unsure, or you think that this actually a Krypton issue, especially if you see org.kryptonmc at the top of the trace, please report this to https://github.com/KryptonMC/Krypton/issues
+        // When reporting to Krypton, please ensure that you include all relevant console errors and thread dumps, as this will help us diagnose your issue easier.
+        // Krypton version: {0} (for Minecraft {1})
+        val STOPPED = doubleText("watchdog.stopped")
+
+        object DumpMessages {
+
+            // Server thread dump (look for plugins here before reporting this to Krypton):
+            val SERVER = empty("watchdog.dump.server")
+
+            // Entire Thread Dump:
+            val ALL = empty("watchdog.dump.all")
+
+            // Current Thread: {0}
+            val THREAD = singleText("watchdog.dump.thread")
+
+            // \tPID: {0} | Suspended: {1} | Native: {2} | State: {3}
+            val INFO = Args4<Long, Boolean, Boolean, Thread.State> { pid, suspended, native, state ->
+                translatable("krypton.watchdog.dump.info", listOf(text(pid), text(suspended), text(native), text(state.toString())))
+            }
+
+            // \tThread is waiting on monitor(s):
+            val MONITORS = empty("watchdog.dump.monitors")
+
+            // \t\tLocked on: {0}
+            val MONITOR = Args1<StackTraceElement> { translatable("krypton.watchdog.dump.monitor", listOf(text(it.toString()))) }
+
+            // \tStack:
+            val STACK = empty("watchdog.dump.stack")
+
+            // \t\t{0}
+            val STACK_ELEMENT = Args1<StackTraceElement> { translatable("krypton.watchdog.dump.stack.element", listOf(text(it.toString()))) }
+        }
+    }
+
+    object WorldMessages {
+
+        // Loading world {0}...
+        val LOAD = singleText("world.load")
+
+        // World loaded!
+        val LOADED = empty("world.loaded")
+
+        // Error loading world {0}!
+        val LOAD_ERROR = singleText("world.load-error")
+
+        // World with name {0} does not exist!
+        val NOT_FOUND = singleText("world.not-found")
+    }
+
+    object RegionMessages {
+
+        val SECTOR = SectorMessages
+        val CHUNK = ChunkMessages
+
+        // Region file {0} has truncated header: {1}
+        val TRUNCATED = Args2<Path, Int> { path, first -> translatable("krypton.region.truncated", listOf(text(path.toString()), text(first))) }
+
+        object SectorMessages {
+
+            // Region file {0} has an invalid sector at index {1}. Sector {2} overlaps with header
+            val OVERLAP = Args3<Path, Int, Int> { path, index, sector ->
+                translatable("krypton.region.sector.overlap", listOf(text(path.toString()), text(index), text(sector)))
+            }
+
+            // Region file {0} has an invalid sector at index {1}. Size has to be > 0
+            val SIZE = Args2<Path, Int> { path, index -> translatable("krypton.region.sector.size", listOf(text(path.toString()), text(index))) }
+
+            // Region file {0} has an invalid sector at index {1}. Sector {2} is out of bounds
+            val OUT_OF_BOUNDS = Args3<Path, Int, Int> { path, index, sector ->
+                translatable("krypton.region.sector.out-of-bounds", listOf(text(path.toString()), text(index), text(sector)))
+            }
+        }
+
+        object ChunkMessages {
+
+            val EXTERNAL = ExternalMessages
+
+            // Chunk {0}'s header is truncated! Expected {1} but got {2}!
+            val TRUNCATED = Args3<ChunkPosition, Long, Int> { position, expected, reality ->
+                translatable("krypton.region.chunk.truncated", listOf(text(position.toString()), text(expected), text(reality)))
+            }
+
+            // Chunk {0} is allocated, but stream is missing.
+            val NO_STREAM = Args1<ChunkPosition> { position -> translatable("krypton.region.chunk.no-stream", listOf(text(position.toString()))) }
+
+            // Chunk has both internal and external streams.
+            val INTERNAL_EXTERNAL = empty("region.chunk.internal-external")
+
+            // Chunk {0}'s stream is truncated! Expected {1} but got {2}
+            val STREAM_TRUNCATED = Args3<ChunkPosition, Int, Int> { position, expected, reality ->
+                translatable("krypton.region.chunk.stream-truncated", listOf(text(position.toString()), text(expected), text(reality)))
+            }
+
+            // Declared size {0} of chunk {1} is negative!
+            val NEGATIVE = Args2<Int, ChunkPosition> { size, position ->
+                translatable("krypton.region.chunk.negative", listOf(text(size), text(position.toString())))
+            }
+
+            // Chunk {0} has an invalid compression type! Type: {1}
+            val INVALID_COMPRESSION_TYPE = doubleText("region.chunk.invalid-compression-type")
+
+            object ExternalMessages {
+
+                // Saving oversized chunk {0} ({1} bytes) to external file {2}.
+                val SAVE = Args3<ChunkPosition, Int, Path> { position, size, path ->
+                    translatable("krypton.region.chunk.external.save", listOf(text(position.toString()), text(size), text(path.toString())))
+                }
+
+                // External chunk path {0} is not a file!
+                val NOT_FILE = Args1<Path> { translatable("krypton.region.chunk.external.not-file", listOf(text(it.toString()))) }
+            }
+        }
+    }
+
+    object AuthMessages {
+
+        // Failed to verify username {0}!
+        val FAIL = singleText("auth.fail")
+
+        // UUID of player {0} is {1}
+        val SUCCESS = Args2<String, UUID> { name, uuid -> translatable("krypton.auth.success", listOf(text(name), text(uuid.toString()))) }
+    }
+
+    object CommandMessages {
+
+        // You do not have permission to execute this command!
+        val NO_PERMISSION = empty("command.no-permission")
+
+        // Unknown command {0}.
+        val UNKNOWN = singleText("command.unknown")
+    }
+
+    object CommandsMessages {
+
+        // Failed to save debug dump!
+        val DEBUG_SAVE_ERROR = empty("commands.debug-save-error")
+
+        // Stopping server...
+        val STOP = empty("commands.stop")
+
+        // Attempting to restart the server...
+        val RESTART = empty("commands.restart")
+    }
+
+    object BungeeMessages {
+
+        // Please notify the server administrator that they are attempting to use BungeeCord IP forwarding without enabling BungeeCord support in their configuration file.
+        val NOTIFY = empty("bungee.notify")
+
+        // Could not decode BungeeCord handshake data! Please report this to an administrator!
+        val FAIL_DECODE = empty("bungee.fail-decode")
+
+        // Error decoding BungeeCord handshake data! Please report this to Krypton!
+        val FAIL_DECODE_ERROR = empty("bungee.fail-decode.error")
+
+        // You are unable to directly connect to this server, as it has BungeeCord enabled in the configuration.
+        val DIRECT = empty("bungee.direct")
+
+        // Attempted connection from {0} not from BungeeCord when BungeeCord compatibility enabled.
+        val DIRECT_WARN = singleText("bungee.direct.warn")
+    }
+
+    object NetworkMessages {
+
+        val LOGIN = LoginMessages
+        val COMPRESS = CompressMessages
+
+        // {0} tried to change their held item slot to an invalid value!
+        val INVALID_HELD_SLOT = singleText("network.invalid-held-slot")
+
+        // Internal Exception:
+        val HANDLER_ERROR_DISCONNECT = empty("network.handler-error-disconnect")
+
+        object LoginMessages {
+
+            // Verify tokens did not match!
+            val FAIL_VERIFY = empty("network.login.fail-verify")
+
+            // {0} failed verification! Expected {1}, received {2}!
+            val FAIL_VERIFY_ERROR = tripleText("network.login.fail-verify.error")
+        }
+
+        object CompressMessages {
+
+            // Packet badly compressed! Size of {0} is below threshold of {1}!
+            val BELOW_THRESHOLD = doubleText("network.compress.below-threshold")
+
+            // Packet badly compressed! Size of {0} is larger than protocol maximum of {1}!
+            val STUPIDLY_LARGE = doubleText("network.compress.stupidly-large")
+        }
+    }
+
+    object PluginMessages {
+
+        val LOAD = LoadMessages
+        val INIT = InitMessages
+        val SHUTDOWN = ShutdownMessages
+
+        object LoadMessages {
+
+            val ERROR = ErrorMessages
+
+            // Loading plugins...
+            val INITIAL = empty("plugin.load")
+
+            // Plugin loading done!
+            val DONE = empty("plugin.load.done")
+
+            // Loading {0} version {1}...
+            val START = doubleText("plugin.load.start")
+
+            // Successfully loaded {0} version {1}
+            val SUCCESS = doubleText("plugin.load.success")
+
+            object ErrorMessages {
+
+                // Could not find main class for plugin {0}!
+                val NO_MAIN = singleText("plugin.load.error.no-main")
+
+                // Main class of {0} does not extend Plugin!
+                val DOES_NOT_EXTEND = singleText("plugin.load.error.does-not-extend")
+
+                // Main class of {0} does not have a constructor that accepts a plugin context!
+                val NO_CONSTRUCTOR = singleText("plugin.load.error.no-constructor")
+
+                // Main class of {0}'s primary constructor is not open!
+                val CONSTRUCTOR_CLOSED = singleText("plugin.load.error.constructor-closed")
+
+                // Main class of {0} must not be abstract!
+                val ABSTRACT = singleText("plugin.load.error.abstract")
+
+                // Main class of {0} threw an exception!
+                val INSTANTIATION = singleText("plugin.load.error.instantiation")
+
+                // An unexpected exception occurred when attempting to load the main class of {0}!
+                val UNEXPECTED = singleText("plugin.load.error.unexpected")
+            }
+        }
+
+        object InitMessages {
+
+            // Initializing {0} version {1}...
+            val START = doubleText("plugin.init")
+
+            // Successfully initialized {0} version {1}
+            val SUCCESS = doubleText("plugin.init.success")
+        }
+
+        object ShutdownMessages {
+
+            // Shutting down {0} version {1}...
+            val START = doubleText("plugin.shutdown")
+
+            // Successfully shutdown {0} version {1}
+            val SUCCESS = doubleText("plugin.shutdown.success")
+        }
+    }
+
+    object GUIMessages {
+
+        val STATS = StatsMessages
+
+        // Krypton - shutting down...
+        val SHUTDOWN_TITLE = empty("gui.shutdown-title")
+
+        // Could not build server GUI!
+        val CANNOT_BUILD = empty("gui.cannot-build")
+
+        object StatsMessages {
+
+            // Memory use: {0} MB ({1}% free)
+            val MEMORY = doubleText("gui.stats.memory")
+
+            // Heap: {0} / {1} MB
+            val HEAP = doubleText("gui.stats.heap")
+
+            // Average tick: {0} ms
+            val TICK = doubleText("gui.stats.tick")
+
+            // <html><body>Used: {0} MB ({1}%)<br/>{2}</body></html>
+            val TOOLTIP = tripleText("gui.stats.tooltip")
+        }
+    }
+
+    object QueryMessages {
+
+        // Query running on {0}:{1}
+        val RUNNING = doubleText("query.running")
+
+        // Failed to recover from exception! Shutting down...
+        val CANNOT_RECOVER = empty("query.cannot-recover")
+
+        // Unable to initialise query system on {0}:{1}
+        val INITIALIZE = doubleText("query.initialize")
+
+        // Invalid query port! Should be between 0 and 65535, was {0}. Querying disabled.
+        val INVALID_PORT = singleText("query.invalid-port")
+    }
+
+    object JMXMessages {
+
+        // Historical tick times in ms
+        val HISTORICAL = empty("jmx.historical")
+
+        // Average tick time in ms
+        val AVERAGE = empty("jmx.average")
+
+        // Simple metrics for Krypton
+        val DESCRIPTION = empty("jmx.description")
+
+        // Failed to register server as a JMX bean!
+        val REGISTER_ERROR = empty("jmx.register-error")
+    }
+
+    object ProfilerMessages {
+
+        val ERROR = ErrorMessages
+
+        // push
+        val PUSH = empty("profiler.push")
+
+        // pop
+        val POP = empty("profiler.pop")
+
+        // Recorded long tick -- wrote info to {0}
+        val TICK_RECORDED = singleText("profiler.tick-recorded")
+
+        // This is approximately {0} ticks per second. It should be 20 ticks per second.
+        val TPS = singleText("profiler.tps")
+
+        object ErrorMessages {
+
+            // Profiler tick has already been started! Perhaps we didn't call end?
+            val STARTED = empty("profiler.error.started")
+
+            // Profiler tick has already ended! Perhaps we didn't call start?
+            val ENDED = empty("profiler.error.ended")
+
+            // Profiler tick was ended before path was fully popped ({0} remaining)! Perhaps push and pop are mismatched?
+            val NOT_FULLY_POPPED = singleText("profiler.error.not-fully-popped")
+
+            // You need to start profiling before attempting to push data! Ignoring attempt to {0} {1}
+            val NOT_STARTED = doubleText("profiler.error.not-started")
+
+            // Tried to pop one too many times! Perhaps push and pop are mismatched?
+            val TOO_MANY_POPS = empty("profiler.error.too-many-pops")
+
+            // Something's taking too long! {0} took approximately {1} ms
+            val TOO_LONG = doubleText("profiler.error.too-long")
+        }
+    }
+
+    object ThreadMessages {
+
+        // Thread {0} started
+        val START = singleText("thread.start")
+
+        // Waited {0} seconds, attempting to force stop.
+        val STOP_FORCE = singleText("thread.stop-force")
+
+        // Thread {0} ({1}) failed to exit after {2} second(s)
+        val STOP_FORCE_ERROR = tripleText("thread.stop-force.error")
+
+        // Thread {0} stopped
+        val STOPPED = singleText("thread.stopped")
+    }
+}
+
+private fun empty(key: String) = Messages.Args0 { translatable("krypton.$key") }
+
+private fun singleText(key: String) = Messages.Args1<String> { translatable("krypton.$key", listOf(text(it))) }
+
+private fun doubleText(key: String) = Messages.Args2<String, String> { a, b -> translatable("krypton.$key", listOf(text(a), text(b))) }
+
+private fun tripleText(key: String) = Messages.Args3<String, String, String> { a, b, c ->
+    translatable("krypton.$key", listOf(text(a), text(b), text(c)))
+}
+
+private fun quadText(key: String) = Messages.Args4<String, String, String, String> { a, b, c, d ->
+    translatable("krypton.$key", listOf(text(a), text(b), text(c), text(d)))
+}
+
+private fun sixText(key: String) = Messages.Args6<String, String, String, String, String, String> { a, b, c, d, e, f ->
+    translatable("krypton.$key", listOf(text(a), text(b), text(c), text(d), text(e), text(f)))
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/locale/Messages.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/locale/Messages.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.locale
 
 import net.kyori.adventure.text.Component

--- a/server/src/main/kotlin/org/kryptonmc/krypton/locale/TranslationManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/locale/TranslationManager.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.locale
 
 import net.kyori.adventure.key.Key

--- a/server/src/main/kotlin/org/kryptonmc/krypton/locale/TranslationManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/locale/TranslationManager.kt
@@ -1,0 +1,110 @@
+package org.kryptonmc.krypton.locale
+
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.translation.GlobalTranslator
+import net.kyori.adventure.translation.TranslationRegistry
+import net.kyori.adventure.translation.Translator
+import net.kyori.adventure.util.UTF8ResourceBundleControl
+import org.kryptonmc.krypton.CURRENT_DIRECTORY
+import org.kryptonmc.krypton.util.logger
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Locale
+import java.util.PropertyResourceBundle
+import java.util.ResourceBundle
+import java.util.concurrent.ConcurrentHashMap
+import java.util.stream.Collectors
+
+object TranslationManager {
+
+    private val DEFAULT_LOCALE: Locale = Locale.ENGLISH
+    val TRANSLATIONS_DIRECTORY: Path = CURRENT_DIRECTORY.resolve("translations")
+    private val LOGGER = logger<TranslationManager>()
+
+    private val installed = ConcurrentHashMap.newKeySet<Locale>()
+    private lateinit var registry: TranslationRegistry
+    @Volatile var locale = DEFAULT_LOCALE
+
+    fun reload(locale: Locale = this.locale) {
+        this.locale = locale
+        if (::registry.isInitialized) {
+            GlobalTranslator.get().removeSource(registry)
+            installed.clear()
+        }
+
+        registry = TranslationRegistry.create(Key.key("krypton", "main"))
+        registry.defaultLocale(DEFAULT_LOCALE)
+
+        loadCustom()
+        loadBase()
+
+        GlobalTranslator.get().addSource(registry)
+    }
+
+    private fun loadBase() {
+        val bundle = ResourceBundle.getBundle("krypton", DEFAULT_LOCALE, UTF8ResourceBundleControl.get())
+        try {
+            registry.registerAll(DEFAULT_LOCALE, bundle, false)
+        } catch (exception: IllegalArgumentException) {
+            LOGGER.warn("Error loading default locale file", exception)
+        }
+    }
+
+    private fun loadCustom() {
+        val translationFiles = try {
+            Files.list(TRANSLATIONS_DIRECTORY).use { stream ->
+                stream.filter { it.fileName.toString().endsWith(".properties") }.collect(Collectors.toList())
+            }
+        } catch (exception: IOException) {
+            emptyList()
+        }
+
+        val loaded = mutableMapOf<Locale, ResourceBundle>()
+        translationFiles.forEach { file ->
+            try {
+                loadCustomTranslationFile(file)?.let { loaded += it }
+            } catch (exception: Exception) {
+                LOGGER.warn("Error loading locale file ${file.fileName}", exception)
+            }
+        }
+
+        loaded.forEach { (locale, bundle) ->
+            val localeWithoutCountry = Locale(locale.language)
+            if (locale != localeWithoutCountry && localeWithoutCountry != DEFAULT_LOCALE && installed.add(localeWithoutCountry)) {
+                registry.registerAll(localeWithoutCountry, bundle, false)
+            }
+        }
+    }
+
+    private fun loadCustomTranslationFile(file: Path): Pair<Locale, ResourceBundle>? {
+        val fileName = file.fileName.toString()
+        val localeString = fileName.substring(0, fileName.length - ".properties".length)
+        val locale = localeString.toLocale()
+
+        if (locale == null) {
+            LOGGER.warn("Unknown locale '$localeString' - unable to register.")
+            return null
+        }
+
+        val bundle = try {
+            Files.newBufferedReader(file, Charsets.UTF_8).use { PropertyResourceBundle(it) }
+        } catch (exception: IOException) {
+            LOGGER.warn("Error loading locale file $localeString", exception)
+            return null
+        }
+
+        try {
+            registry.registerAll(locale, bundle, true)
+        } catch (exception: Exception) {
+            return null
+        }
+        installed += locale
+        return locale to bundle
+    }
+
+    fun render(component: Component) = GlobalTranslator.render(component, locale)
+}
+
+fun String.toLocale() = Translator.parseLocale(this)

--- a/server/src/main/kotlin/org/kryptonmc/krypton/locale/TranslationRepository.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/locale/TranslationRepository.kt
@@ -1,0 +1,55 @@
+package org.kryptonmc.krypton.locale
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+import org.kryptonmc.krypton.GSON
+import org.kryptonmc.krypton.util.createDirectories
+import java.util.concurrent.ForkJoinPool
+import kotlin.io.path.bufferedReader
+import kotlin.io.path.bufferedWriter
+import kotlin.io.path.exists
+
+object TranslationRepository {
+
+    private const val CACHE_MAX_AGE = 900_000 // 15 minutes in milliseconds
+
+    fun scheduleRefresh() = ForkJoinPool.commonPool().execute { refresh() }
+
+    private fun refresh() {
+        val translationsDirectory = TranslationManager.TRANSLATIONS_DIRECTORY.apply { createDirectories() }
+
+        val repoStatusFile = translationsDirectory.resolve("repository.json")
+        val lastRefresh = if (repoStatusFile.exists()) {
+            repoStatusFile.bufferedReader().use {
+                val status = GSON.fromJson(it, JsonObject::class.java)
+                if (status.has("lastRefresh")) status["lastRefresh"].asLong else 0L
+            }
+        } else 0L
+
+        val timeSinceLastRefresh = System.currentTimeMillis() - lastRefresh
+        if (timeSinceLastRefresh <= CACHE_MAX_AGE) return
+
+        val metadata = metadata
+        if (timeSinceLastRefresh <= metadata.cacheMaxAge) return
+
+        downloadAndInstall(metadata.languages, true)
+    }
+
+    fun downloadAndInstall(languages: List<LanguageInfo>, updateStatus: Boolean) {
+        val translationsDirectory = TranslationManager.TRANSLATIONS_DIRECTORY.apply { createDirectories() }
+        languages.forEach { TranslationRequester.download(it.locale.toString(), translationsDirectory.resolve("${it.locale}.properties")) }
+
+        if (updateStatus) {
+            val repoStatusFile = translationsDirectory.resolve("repository.json")
+            repoStatusFile.bufferedWriter().use {
+                val status = JsonObject().apply { add("lastRefresh", JsonPrimitive(System.currentTimeMillis())) }
+                GSON.toJson(status, it)
+            }
+        }
+
+        TranslationManager.reload()
+    }
+
+    val metadata: MetadataResponse
+        get() = TranslationRequester.metadata()
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/locale/TranslationRepository.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/locale/TranslationRepository.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.locale
 
 import com.google.gson.JsonObject

--- a/server/src/main/kotlin/org/kryptonmc/krypton/locale/TranslationService.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/locale/TranslationService.kt
@@ -1,0 +1,121 @@
+package org.kryptonmc.krypton.locale
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import okhttp3.ResponseBody
+import org.apache.logging.log4j.Logger
+import org.kryptonmc.krypton.GSON
+import org.kryptonmc.krypton.util.logger
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.create
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.Path
+import retrofit2.http.Streaming
+import java.io.Closeable
+import java.io.FilterInputStream
+import java.io.IOException
+import java.io.InputStream
+import java.lang.reflect.Type
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.util.Locale
+
+interface TranslationService {
+
+    @GET("data/translations")
+    fun data(): Call<MetadataResponse>
+
+    @GET("translation/{id}")
+    @Streaming
+    fun download(@Path("id") id: String): Call<ResponseBody>
+}
+
+object TranslationRequester {
+
+    private const val DATA_URL = "https://data.kryptonmc.org/"
+    private const val MAX_BUNDLE_SIZE = 1048576L // 1MB
+
+    private val service = Retrofit.Builder()
+        .baseUrl(DATA_URL)
+        .addConverterFactory(GsonConverterFactory.create(GSON))
+        .build()
+        .create<TranslationService>()
+
+    fun metadata() = service.data().executeSuccess(LOGGER)
+
+    fun download(id: String, file: java.nio.file.Path) {
+        try {
+            val request = service.download(id).execute()
+            if (!request.isSuccessful) return
+            LimitedInputStream(request.body()!!.byteStream(), MAX_BUNDLE_SIZE).use {
+                Files.copy(it, file, StandardCopyOption.REPLACE_EXISTING)
+            }
+        } catch (exception: IOException) {
+            LOGGER.warn("Unable to download translations", exception)
+        }
+    }
+
+    private val LOGGER = logger<TranslationRequester>()
+}
+
+class MetadataResponse(val cacheMaxAge: Long, val languages: List<LanguageInfo>) {
+
+    companion object : JsonDeserializer<MetadataResponse> {
+
+        override fun deserialize(src: JsonElement, type: Type, context: JsonDeserializationContext): MetadataResponse {
+            src as JsonObject
+            val cacheMaxAge = src["cacheMaxAge"].asLong
+            val languages = src["languages"].asJsonArray.map { LanguageInfo(it.asJsonObject) }
+            return MetadataResponse(cacheMaxAge, languages)
+        }
+    }
+}
+
+data class LanguageInfo(val id: String, val name: String, val locale: Locale, val progress: Int, val contributors: List<String>) {
+
+    constructor(data: JsonObject) : this(
+        data["id"].asString,
+        data["name"].asString,
+        data["tag"].asString.toLocale()!!,
+        data["progress"].asInt,
+        data["contributors"].asJsonArray.map { it.asJsonObject["name"].asString }
+    )
+}
+
+private class LimitedInputStream(input: InputStream, private val limit: Long) : FilterInputStream(input), Closeable {
+
+    private var count = 0L
+
+    private fun checkLimit() {
+        if (count > limit) throw IOException("Limit exceeded!")
+    }
+
+    override fun read(): Int {
+        val result = super.read()
+        if (result != -1) {
+            count++
+            checkLimit()
+        }
+        return result
+    }
+
+    override fun read(b: ByteArray, off: Int, len: Int): Int {
+        val result = super.read(b, off, len)
+        if (result > 0) {
+            count += result
+            checkLimit()
+        }
+        return result
+    }
+}
+
+private fun <T> Call<T>.executeSuccess(logger: Logger): T {
+    val response = execute()
+    require(response.isSuccessful) { "${request()} unsuccessful! Code: ${response.code()}, Error body: ${response.errorBody()?.string()}".apply { logger.error(this) } }
+    return response.body()!!
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/locale/TranslationService.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/locale/TranslationService.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.locale
 
 import com.google.gson.JsonDeserializationContext

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInPlayerDigging.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/in/play/PacketInPlayerDigging.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.`in`.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutAcknowledgePlayerDigging.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutAcknowledgePlayerDigging.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutBossBar.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutBossBar.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutOpenBook.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/PacketOutOpenBook.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityTeleport.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/entity/PacketOutEntityTeleport.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.entity
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/sound/PacketOutNamedSoundEffect.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/sound/PacketOutNamedSoundEffect.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.sound
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/sound/PacketOutSoundEffect.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/sound/PacketOutSoundEffect.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.sound
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/sound/PacketOutStopSound.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/sound/PacketOutStopSound.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.sound
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/window/PacketOutSetSlot.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/packet/out/play/window/PacketOutSetSlot.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.packet.out.play.window
 
 import io.netty.buffer.ByteBuf

--- a/server/src/main/kotlin/org/kryptonmc/krypton/scheduling/KryptonTask.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/scheduling/KryptonTask.kt
@@ -21,6 +21,7 @@ package org.kryptonmc.krypton.scheduling
 import org.kryptonmc.api.plugin.Plugin
 import org.kryptonmc.api.scheduling.Task
 import org.kryptonmc.api.scheduling.TaskState
+import org.kryptonmc.krypton.locale.Messages
 import org.kryptonmc.krypton.util.logger
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -69,7 +70,7 @@ data class KryptonTask(
                 Thread.currentThread().interrupt()
                 return@execute
             }
-            LOGGER.error("Plugin ${plugin.context.description.name} generated an exception from task $runnable")
+            Messages.SCHEDULE_ERROR.error(LOGGER, plugin.context.description.name, runnable)
         } finally {
             if (period == 0L) finish()
             currentTaskThread = null

--- a/server/src/main/kotlin/org/kryptonmc/krypton/serializers/DifficultySerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/serializers/DifficultySerializer.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.serializers
 
 import org.kryptonmc.api.world.Difficulty

--- a/server/src/main/kotlin/org/kryptonmc/krypton/serializers/GamemodeSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/serializers/GamemodeSerializer.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.serializers
 
 import org.kryptonmc.api.world.Gamemode

--- a/server/src/main/kotlin/org/kryptonmc/krypton/serializers/IntOrStringEnumSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/serializers/IntOrStringEnumSerializer.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.serializers
 
 import com.google.gson.JsonDeserializationContext

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/bytebufs.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/bytebufs.kt
@@ -27,6 +27,7 @@ import net.kyori.adventure.nbt.BinaryTagIO
 import net.kyori.adventure.nbt.CompoundBinaryTag
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
+import net.kyori.adventure.translation.GlobalTranslator
 import org.kryptonmc.api.effect.particle.BlockParticleData
 import org.kryptonmc.api.effect.particle.ColorParticleData
 import org.kryptonmc.api.effect.particle.DirectionalParticleData
@@ -41,6 +42,8 @@ import org.kryptonmc.api.world.Location
 import org.kryptonmc.krypton.entity.Slot
 import org.kryptonmc.krypton.entity.entities.data.VillagerData
 import org.kryptonmc.krypton.entity.metadata.Optional
+import org.kryptonmc.krypton.locale.TranslationManager
+import org.kryptonmc.krypton.locale.TranslationRepository
 import org.kryptonmc.krypton.registry.Registries
 import java.io.ByteArrayOutputStream
 import java.io.IOException
@@ -199,7 +202,7 @@ fun ByteBuf.readNBTCompound(): CompoundBinaryTag {
 }
 
 fun ByteBuf.writeChat(component: Component) {
-    writeString(GsonComponentSerializer.gson().serialize(component))
+    writeString(GsonComponentSerializer.gson().serialize(TranslationManager.render(component)))
 }
 
 fun ByteBuf.writeOptionalChat(component: Optional<Component>) {

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/json.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/json.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util
 
 import com.google.gson.Gson

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/reports/CrashReport.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/reports/CrashReport.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.reports
 
 import okhttp3.internal.closeQuietly

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/reports/CrashReportCategory.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/reports/CrashReportCategory.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.reports
 
 class CrashReportCategory(private val title: String) {

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/reports/ReportedException.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/reports/ReportedException.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.util.reports
 
 import java.lang.RuntimeException

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/KryptonWorldManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/KryptonWorldManager.kt
@@ -31,6 +31,7 @@ import org.kryptonmc.api.world.Gamemode
 import org.kryptonmc.api.world.World
 import org.kryptonmc.api.world.WorldManager
 import org.kryptonmc.api.world.WorldVersion
+import org.kryptonmc.krypton.locale.Messages
 import org.kryptonmc.krypton.util.concurrent.NamedThreadFactory
 import org.kryptonmc.krypton.util.logger
 import org.kryptonmc.krypton.world.dimension.Dimension
@@ -61,19 +62,22 @@ class KryptonWorldManager(override val server: KryptonServer, name: String) : Wo
 
     init {
         default = try {
-            LOGGER.info("Loading world $name...")
+            Messages.WORLD.LOAD.info(LOGGER, name)
             load(name).get()
         } catch (exception: Exception) {
-            if (exception !is IllegalArgumentException) LOGGER.error("Exception loading world $name!", exception)
+            if (exception !is IllegalArgumentException) Messages.WORLD.LOAD_ERROR.error(LOGGER, name, exception)
             exitProcess(0)
         }
         worlds[name] = default
-        LOGGER.info("World loaded!")
+        Messages.WORLD.LOADED.info(LOGGER)
     }
 
     override fun load(name: String): Future<KryptonWorld> {
         val folder = CURRENT_DIRECTORY.resolve(name)
-        require(folder.exists()) { "World with name $name does not exist!".apply { LOGGER.error(this) } }
+        require(folder.exists()) {
+            Messages.WORLD.NOT_FOUND.error(LOGGER, name)
+            "World with name $name does not exist!"
+        }
         return loadWorld(folder)
     }
 

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/bossbar/BossBarManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/bossbar/BossBarManager.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.world.bossbar
 
 import com.google.common.collect.MapMaker

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/chunk/KryptonChunk.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/chunk/KryptonChunk.kt
@@ -26,6 +26,7 @@ import org.kryptonmc.api.world.Biome
 import org.kryptonmc.api.world.Location
 import org.kryptonmc.api.world.World
 import org.kryptonmc.api.world.chunk.Chunk
+import org.kryptonmc.krypton.locale.Messages
 import org.kryptonmc.krypton.util.logger
 import org.kryptonmc.krypton.world.Heightmap
 import org.kryptonmc.krypton.world.HeightmapBuilder
@@ -71,7 +72,7 @@ data class KryptonChunk(
 
         val sectionY = y shr 4
         if (sectionY !in 0..15) {
-            LOGGER.warn("Attempted to place block $block under/over the world! The section at $sectionY cannot be set!")
+            Messages.BLOCK_UNDER_WORLD.warn(LOGGER, block, sectionY)
             return false
         }
 

--- a/server/src/main/resources/krypton_en.properties
+++ b/server/src/main/resources/krypton_en.properties
@@ -1,0 +1,131 @@
+krypton.version-info=Krypton version {0} for Minecraft {1}
+krypton.load=Starting Krypton server version {0} for Minecraft {1}
+krypton.load.low-memory=\
+  You''re starting the server with {0} megabytes of RAM.\n\
+  Consider starting it with more by using \"java -Xmx1024M -Xms1024M -jar Krypton-{1}.jar\" to start it with 1 GB RAM.
+krypton.error.bind=\
+  FAILED TO BIND TO PORT {0}\n\
+  Exception: {1}\n\
+  Perhaps a server is already running on that port?
+krypton.start=Starting Krypton server on {0}:{1}...
+krypton.start.query=Starting GS4 status listener...
+krypton.start.done=Done ({0})! Type \"help\" for help.
+krypton.piracy-warning=\
+  SERVER IS IN OFFLINE MODE! THIS SERVER WILL MAKE NO ATTEMPTS TO AUTHENTICATE USERS!\n\
+  While this may allow players without full Minecraft accounts to connect, it also allows hackers to connect with any username they choose! Beware!\n\
+  To get rid of this message, change online-mode to true in config.conf
+krypton.overload-warning=Woah there! Can''t keep up! Running {0}ms ({1} ticks) behind!
+krypton.autosave.started=Autosave started
+krypton.autosave.finished=Autosave finished
+krypton.stop=Stopping Krypton...
+krypton.stop.save=Saving player, world and region data...
+krypton.stop.plugins=Shutting down plugins...
+krypton.stop.goodbye=Goodbye
+krypton.restart.attempt=Attempting to restart the server with script {0}...
+krypton.restart.no-script=Unable to find restart script {0}! Refusing to restart.
+krypton.metrics.info=\
+  Krypton and some of its plugins collect metrics and send them to bStats (https://bstats.org).\n\
+  bStats collects some basic information for plugin authors, like how many people use\n\
+  their plugin and their total player count. It''s recommended to keep bStats enabled, but\n\
+  if you''re not comfortable with this, you can opt-out by editing the config.txt file in\n\
+  the ''/plugins/bStats/'' folder and setting enabled to false.
+krypton.watchdog.header=---- DO NOT REPORT THIS TO KRYPTON! THIS IS NOT A BUG OR CRASH! ----
+krypton.watchdog.warning=The server has not responded for {0} seconds! Creating thread dump...
+krypton.watchdog.dump.server=Server thread dump (look for plugins here before reporting this to Krypton):
+krypton.watchdog.dump.all=Entire Thread Dump:
+krypton.watchdog.dump.thread=Current Thread: {0}
+krypton.watchdog.dump.info=\tPID: {0} | Suspended: {1} | Native: {2} | State: {3}
+krypton.watchdog.dump.monitors=\tThread is waiting on monitor(s):
+krypton.watchdog.dump.monitor=\t\tLocked on: {0}
+krypton.watchdog.dump.stack=\tStack:
+krypton.watchdog.dump.stack.element=\t\t{0}
+krypton.watchdog.stopped=\
+  The server has stopped responding! This could be, but is not likely to be, an issue with Krypton.\n\
+  If you see a plugin in the server thread dump below, then please report it to that author.\n\
+  \t *Especially* if it looks like HTTP or MySQL operations are occurring\n\
+  If you see a world save or edit, then it likely means you tried to do much more than your server can handle at once\n\
+  \t If this is the case, consider increasing timeout-time in the main configuration file. Please note, however, that this will replace this crash with LARGE lag spikes\n\
+  If you are still unsure, or you think that this actually a Krypton issue, especially if you see org.kryptonmc at the top of the trace, please report this to https://github.com/KryptonMC/Krypton/issues\n\
+  When reporting to Krypton, please ensure that you include all relevant console errors and thread dumps, as this will help us diagnose your issue easier.\n\
+  Krypton version: {0} (for Minecraft {1})
+krypton.world.load=Loading world {0}...
+krypton.world.loaded=World loaded!
+krypton.world.load-error=Error loading world {0}!
+krypton.world.not-found=World with name {0} does not exist!
+krypton.block.under-world=Attempted to place block {0} under/over the world! The section at {1} cannot be set!
+krypton.region.truncated=Region file {0} has truncated header: {1}
+krypton.region.sector.overlap=Region file {0} has an invalid sector at index {1}. Sector {2} overlaps with header
+krypton.region.sector.size=Region file {0} has an invalid sector at index {1}. Size has to be > 0
+krypton.region.sector.out-of-bounds=Region file {0} has an invalid sector at index {1}. Sector {2} is out of bounds
+krypton.region.chunk.truncated=Chunk {0}'s header is truncated! Expected {1} but got {2}!
+krypton.region.chunk.no-stream=Chunk {0} is allocated, but stream is missing.
+krypton.region.chunk.internal-external=Chunk has both internal and external streams.
+krypton.region.chunk.stream-truncated=Chunk {0}'s stream is truncated! Expected {1} but got {2}
+krypton.region.chunk.negative=Declared size {0} of chunk {1} is negative!
+krypton.region.chunk.external.save=Saving oversized chunk {0} ({1} bytes) to external file {2}.
+krypton.region.chunk.external.not-file=External chunk path {0} is not a file!
+krypton.region.chunk.invalid-compression-type=Chunk {0} has an invalid compression type! Type: {1}
+krypton.auth.fail=Failed to verify username {0}!
+krypton.auth.success=UUID of player {0} is {1}
+krypton.argument-error=Could not serialise {0} (Class {1})! Will not be sent to client!
+krypton.command.no-permission=You do not have permission to execute this command!
+krypton.command.unknown=Unknown command {0}.
+krypton.commands.debug-save-error=Failed to save debug dump!
+krypton.commands.stop=Stopping server...
+krypton.commands.restart=Attempting to restart the server...
+krypton.event-single-argument=Method {0} in class {1} annotated with {2} does not have a single argument!
+krypton.bungee.notify=Please notify the server administrator that they are attempting to use BungeeCord IP forwarding without enabling BungeeCord support in their configuration file.
+krypton.bungee.could-not-decode=Could not decode BungeeCord handshake data! Please report this to an administrator!
+krypton.bungee.could-not-decode.error=Error decoding BungeeCord handshake data! Please report this to Krypton!
+krypton.bungee.direct=You are unable to directly connect to this server, as it has BungeeCord enabled in the configuration.
+krypton.bungee.direct.warn=Attempted connection from {0} not from BungeeCord when BungeeCord compatibility enabled.
+krypton.network.login.fail-verify=Verify tokens did not match!
+krypton.network.login.fail-verify.error={0} failed verification! Expected {1}, received {2}!
+krypton.network.invalid-held-slot={0} tried to change their held item slot to an invalid value!
+krypton.network.compress.below-threshold=Packet badly compressed! Size of {0} is below threshold of {1}!
+krypton.network.compress.stupidly-large=Packet badly compressed! Size of {0} is larger than protocol maximum of {1}!
+krypton.network.handler-error-disconnect=Internal Exception:
+krypton.plugin.load=Loading plugins...
+krypton.plugin.load.done=Plugin loading done!
+krypton.plugin.load.start=Loading {0} version {1}...
+krypton.plugin.load.success=Successfully loaded {0} version {1}
+krypton.plugin.load.error.no-main=Could not find main class for plugin {0}
+krypton.plugin.load.error.does-not-extend=Main class of {0} does not extend Plugin!
+krypton.plugin.load.error.no-constructor=Main class of {0} does not have a constructor that accepts a plugin context!
+krypton.plugin.load.error.constructor-closed=Main class of {0}''s primary constructor is not open!
+krypton.plugin.load.error.abstract=Main class of {0} must not be abstract!
+krypton.plugin.load.error.instantiation=Main class of {0} threw an exception!
+krypton.plugin.load.error.unexpected=An unexpected exception occurred when attempting to load the main class of {0}!
+krypton.plugin.init=Initializing {0} version {1}...
+krypton.plugin.init.success=Successfully initialized {0} version {1}
+krypton.plugin.shutdown=Shutting down {0} version {1}...
+krypton.plugin.shutdown.success=Successfully shutdown {0} version {1}
+krypton.schedule-error=Plugin {0} generated an exception from task {1}
+krypton.gui.shutdown-title=Krypton - shutting down...
+krypton.gui.cannot-build=Could not build server GUI
+krypton.gui.stats.memory=Memory use: {0} MB ({1}% free)
+krypton.gui.stats.heap=Heap: {0} / {1} MB
+krypton.gui.stats.tick=Average tick: {0} ms
+krypton.gui.stats.tooltip=<html><body>Used: {0} MB ({1}%)<br/>{2}</body></html>
+krypton.query.running=Query running on {0}:{1}
+krypton.query.cannot-recover=Failed to recover from exception! Shutting down...
+krypton.query.initialize=Unable to initialise query system on {0}:{1}
+krypton.query.invalid-port=Invalid query port! Should be between 0 and 65535, was {0}. Querying disabled.
+krypton.jmx.historical=Historical tick times in ms
+krypton.jmx.average=Average tick time in ms
+krypton.jmx.description=Simple metrics for Krypton
+krypton.jmx.error.register=Failed to register server as a JMX bean
+krypton.profiler.tick-recorded=Recorded long tick -- wrote info to {0}
+krypton.profiler.push=push
+krypton.profiler.pop=pop
+krypton.profiler.error.started=Profiler tick has already been started! Perhaps we didn''t call end?
+krypton.profiler.error.ended=Profiler tick has already ended! Perhaps we didn''t call start?
+krypton.profiler.error.not-fully-popped=Profiler tick was ended before path was fully popped ({0} remaining)! Perhaps push and pop are mismatched?
+krypton.profiler.error.not-started=You need to start profiling before attempting to push data! Ignoring attempt to {0} {1}
+krypton.profiler.error.too-many-pops=Tried to pop one too many times! Perhaps push and pop are mismatched?
+krypton.profiler.error.too-long=Something''s taking too long! {0} took approximately {1} ms
+krypton.profiler.tps=This is approximately {0} ticks per second. It should be 20 ticks per second.
+krypton.thread.start=Thread {0} started
+krypton.thread.stop.force=Waited {0} seconds, attempting to force stop.
+krypton.thread.stop.force.error=Thread {0} ({1}) failed to exit after {2} second(s)
+krypton.thread.stopped=Thread {0} stopped

--- a/server/src/test/kotlin/org/kryptonmc/krypton/CommandTests.kt
+++ b/server/src/test/kotlin/org/kryptonmc/krypton/CommandTests.kt
@@ -34,6 +34,7 @@ import org.kryptonmc.krypton.command.KryptonCommandManager
 import org.kryptonmc.krypton.command.commands.RestartCommand
 import org.kryptonmc.krypton.command.commands.StopCommand
 import org.kryptonmc.krypton.event.KryptonEventBus
+import org.kryptonmc.krypton.locale.Messages
 import java.security.Permission
 import kotlin.test.Test
 
@@ -70,7 +71,7 @@ class CommandTests {
     @Test
     fun `dispatch actually dispatches`() {
         manager.dispatch(emptySender, "test-def-exec")
-        verify { emptySender.sendMessage(text("You do not have permission to execute this command!", NamedTextColor.RED)) }
+        verify { emptySender.sendMessage(any()) }
     }
 
     @Test


### PR DESCRIPTION
As you can see from the title, this PR adds localisation for the entire server. Most logging messages are customisable, and everything in the GUI and all messages sent to clients should also be customisable.

To go with this change, we also now have a [Crowdin page](https://crowdin.com/project/krypton), which will allow for community submitted translations that will be accessible by the server using the data API.