### PR TITLE
Add more vanilla commands

### DIFF
--- a/api/src/main/kotlin/org/kryptonmc/api/command/PermissionLevel.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/command/PermissionLevel.kt
@@ -1,0 +1,90 @@
+/*
+ * This file is part of the Krypton API, licensed under the MIT license.
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors to the Krypton project.
+ *
+ * This project is licensed under the terms of the MIT license.
+ * For more details, please reference the LICENSE file in the api top-level directory.
+ */
+package org.kryptonmc.api.command
+
+/**
+ * The [permission level](https://minecraft.fandom.com/wiki/Permission_level) is primarily used when a player gets the operator status
+ *
+ * The permission levels get their permissions from the previous levels. So [PermissionLevel.LEVEL_2] gets all permissions from [PermissionLevel.LEVEL_1] plus their own
+ *
+ * And [PermissionLevel.LEVEL_4] gets all permissions from [PermissionLevel.LEVEL_1], [PermissionLevel.LEVEL_2], [PermissionLevel.LEVEL_3] plus their own
+ * @param id The id which will be used to save the operators
+ */
+enum class PermissionLevel(val id: Int) {
+
+    /**
+     * Permission level 1
+     */
+    LEVEL_1(1),
+
+    /**
+     * Permission level 2
+     */
+    LEVEL_2(2),
+
+    /**
+     * Permission level 3
+     */
+    LEVEL_3(3),
+
+    /**
+     * Permission level 4. This permission level normally has all permissions
+     */
+    LEVEL_4(4);
+
+    private val permissions = hashMapOf<String, Boolean>()
+
+    /**
+     * Whether the permission level has the specified [permission]
+     */
+    fun hasPermission(permission: String) = when (this) {
+        LEVEL_1 -> permissions[permission] ?: false
+        LEVEL_2 -> (LEVEL_1.permissions + permissions)[permission] ?: false
+        LEVEL_3 -> (LEVEL_1.permissions + LEVEL_2.permissions + permissions)[permission] ?: false
+        LEVEL_4 -> (LEVEL_1.permissions + LEVEL_2.permissions + LEVEL_3.permissions + permissions)[permission] ?: false
+    }
+
+    /**
+     * Grant the permission level the specified [permission]
+     * @param permission The permission to grant
+     */
+    fun grant(permission: String) {
+        permissions[permission] = true
+    }
+
+    /**
+     * Revoke the [permission] from the permission level
+     * @param permission The permission to revoke
+     */
+    fun revoke(permission: String) {
+        permissions[permission] = false
+    }
+
+    private fun rawPermissions() = permissions.filter { it.value }.keys.toList()
+
+    /**
+     * Returns a list with all permissions the permission level has
+     */
+    fun permissions() = when (this) {
+        LEVEL_1 -> rawPermissions()
+        LEVEL_2 -> rawPermissions() + LEVEL_1.rawPermissions()
+        LEVEL_3 -> rawPermissions() + LEVEL_1.rawPermissions() + LEVEL_2.rawPermissions()
+        LEVEL_4 -> rawPermissions() + LEVEL_1.rawPermissions() + LEVEL_2.rawPermissions() + LEVEL_3.rawPermissions()
+    }
+
+    companion object {
+
+        /**
+         * Gets the [PermissionLevel] from its id
+         * @param id The permission level id
+         */
+        fun fromId(id: Int) = values().firstOrNull { it.id == id }
+
+    }
+}

--- a/api/src/main/kotlin/org/kryptonmc/api/command/Sender.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/command/Sender.kt
@@ -10,11 +10,17 @@ package org.kryptonmc.api.command
 
 import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.identity.Identified
+import org.kryptonmc.api.Server
 
 /**
  * A sender is an interface representing the sender of a command.
  */
 interface Sender : Audience, Identified {
+
+    /**
+     * The sender's permission level
+     */
+    val permissionLevel: PermissionLevel
 
     /**
      * The sender's name
@@ -25,6 +31,11 @@ interface Sender : Audience, Identified {
      * The sender's permissions
      */
     val permissions: Map<String, Boolean>
+
+    /**
+     * The sender's server
+     */
+    val server: Server
 
     /**
      * If the sender has the specified [permission]

--- a/api/src/main/kotlin/org/kryptonmc/api/entity/Entity.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/entity/Entity.kt
@@ -137,4 +137,9 @@ interface Entity : Sender, Identified, HoverEventSource<HoverEvent.ShowEntity>, 
      * one game tick.
      */
     fun remove()
+
+    /**
+     * A helper method to get the distance between two entities
+     */
+    fun distance(entity: Entity) = location.distanceSquared(entity.location)
 }

--- a/api/src/main/kotlin/org/kryptonmc/api/entity/player/Player.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/entity/player/Player.kt
@@ -8,6 +8,7 @@
  */
 package org.kryptonmc.api.entity.player
 
+import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.event.HoverEvent
 import net.kyori.adventure.text.event.HoverEventSource
 import org.kryptonmc.api.block.Block
@@ -126,4 +127,9 @@ interface Player : LivingEntity, Sender, InventoryHolder, PluginMessageRecipient
      * @return the destroy speed
      */
     fun getDestroySpeed(block: Block): Float
+
+    /**
+     * Kicks the player with the given text shown
+     */
+    fun disconnect(text: Component)
 }

--- a/api/src/main/kotlin/org/kryptonmc/api/world/Gamemode.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/world/Gamemode.kt
@@ -8,6 +8,8 @@
  */
 package org.kryptonmc.api.world
 
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.key.Key.key
 import org.kryptonmc.api.world.Gamemode.ADVENTURE
 import org.kryptonmc.api.world.Gamemode.CREATIVE
 import org.kryptonmc.api.world.Gamemode.SPECTATOR
@@ -16,40 +18,47 @@ import org.kryptonmc.api.world.Gamemode.SURVIVAL
 /**
  * Represents a game mode, those being [SURVIVAL], [CREATIVE], [ADVENTURE]
  * and [SPECTATOR].
+ * @param shortName Represents the short name of the given gamemode
  */
 @Suppress("MemberVisibilityCanBePrivate")
-enum class Gamemode {
+enum class Gamemode(val shortName: String) {
 
     /**
      * Plain old survival mode. In this mode, you have a finite amount of health,
      * and you can take damage.
      */
-    SURVIVAL,
+    SURVIVAL("s"),
 
     /**
      * In creative this mode, you are completely invulnerable, you can fly,
      * and you can spawn and use any item you wish.
      */
-    CREATIVE,
+    CREATIVE("c"),
 
     /**
      * Adventure mode is designed for map creators, in that blocks require specific
      * tools to break, and you cannot break them without those tools.
      */
-    ADVENTURE,
+    ADVENTURE("a"),
 
     /**
      * In spectator mode, you are also completely invulnerable, but you can
      * also fly through blocks, as the entire world is essentially non existent
      * to your client (you can see things, but you will never collide with them).
      */
-    SPECTATOR;
+    SPECTATOR("sp");
 
     /**
      * If this gamemode can build.
      */
     val canBuild: Boolean
         get() = this == SURVIVAL || this == CREATIVE
+
+    /**
+     *  Represents the key of the gamemode
+     */
+    val key: Key
+        get() = key("gameMode.${this.name.lowercase()}")
 
     override fun toString() = name.lowercase()
 
@@ -63,5 +72,21 @@ enum class Gamemode {
             if (id !in 0 until values().size) return null
             return values()[id]
         }
+
+        /**
+         * Retrieves a game mode from its name.
+         */
+        @JvmStatic
+        fun fromName(name: String) = try {
+            valueOf(name.uppercase())
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+
+        /**
+         * Retrieves a game mode from its short name
+         */
+        @JvmStatic
+        fun fromShortName(shortName: String) = values().firstOrNull { it.shortName == shortName }
     }
 }

--- a/api/src/main/kotlin/org/kryptonmc/api/world/rule/GameRules.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/world/rule/GameRules.kt
@@ -23,6 +23,8 @@ import org.kryptonmc.api.registry.Registries
 @Suppress("MagicNumber")
 object GameRules {
 
+    val rules = hashMapOf<String, GameRule<*>>()
+
     // @formatter:off
     /**
      * If advancements should be announced to the server.
@@ -309,9 +311,14 @@ object GameRules {
 
     // @formatter:on
     @Suppress("UNCHECKED_CAST")
-    private fun <V : Any> register(key: String, name: String, default: V): GameRule<V> = Registries.register(
-        Registries.GAMERULES,
-        key,
-        GameRule(name, default)
-    ) as GameRule<V>
+    private fun <V : Any> register(key: String, name: String, default: V): GameRule<V> {
+        val rule = Registries.register(
+            Registries.GAMERULES,
+            key,
+            GameRule(name, default)
+        )
+        rules[key] = rule
+        return rule as GameRule<V>
+    }
+
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/Krypton.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/Krypton.kt
@@ -147,7 +147,7 @@ class KryptonCLI : CliktCommand(
         val serverThread = Thread({ reference.get().start() }, "Server Thread").apply {
             setUncaughtExceptionHandler { _, exception -> logger<KryptonServer>().error(exception) }
         }
-        val server = KryptonServer(registryHolder, packRepository, resources, config, worldFolder)
+        val server = KryptonServer(registryHolder, packRepository, resources, config, configFile, worldFolder)
         reference.set(server)
         serverThread.start()
     }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/KryptonSender.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/KryptonSender.kt
@@ -19,16 +19,23 @@
 package org.kryptonmc.krypton.command
 
 import net.kyori.adventure.util.TriState
+import org.kryptonmc.api.command.PermissionLevel
 import org.kryptonmc.api.command.Sender
 import org.kryptonmc.api.event.play.PermissionCheckEvent
 import org.kryptonmc.krypton.KryptonServer
+import org.kryptonmc.krypton.entity.player.KryptonPlayer
 
-abstract class KryptonSender(val server: KryptonServer) : Sender {
+abstract class KryptonSender(override val server: KryptonServer) : Sender {
 
     override val permissions = mutableMapOf<String, Boolean>()
+    override val permissionLevel = PermissionLevel.LEVEL_1
 
     override fun hasPermission(permission: String): Boolean {
-        val event = PermissionCheckEvent(this, permission, permission in permissions)
+        val event = PermissionCheckEvent(
+            this,
+            permission,
+            permission in permissions || permissionLevel.hasPermission(permission)
+        )
         return when (server.eventManager.fireSync(event).result) {
             TriState.TRUE -> true
             TriState.FALSE, TriState.NOT_SET -> false
@@ -37,9 +44,11 @@ abstract class KryptonSender(val server: KryptonServer) : Sender {
 
     override fun grant(permission: String) {
         permissions[permission] = true
+        if (this is KryptonPlayer) server.commandManager.sendCommands(this)
     }
 
     override fun revoke(permission: String) {
         permissions[permission] = false
+        if (this is KryptonPlayer) server.commandManager.sendCommands(this)
     }
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/ArgumentTypes.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/ArgumentTypes.kt
@@ -30,6 +30,8 @@ import org.kryptonmc.krypton.command.argument.serializer.brigadier.FloatArgument
 import org.kryptonmc.krypton.command.argument.serializer.brigadier.IntegerArgumentSerializer
 import org.kryptonmc.krypton.command.argument.serializer.brigadier.LongArgumentSerializer
 import org.kryptonmc.krypton.command.argument.serializer.brigadier.StringArgumentSerializer
+import org.kryptonmc.krypton.command.argument.serializer.minecraft.EntityArgumentSerializer
+import org.kryptonmc.krypton.command.arguments.GameProfileArgument
 import org.kryptonmc.krypton.command.arguments.NBTArgument
 import org.kryptonmc.krypton.command.arguments.NBTCompoundArgument
 import org.kryptonmc.krypton.command.arguments.SummonEntityArgument
@@ -65,6 +67,8 @@ object ArgumentTypes {
         register<NBTCompoundArgument>("nbt_compound_tag", EmptyArgumentSerializer())
         register<SummonEntityArgument>("entity_summon", EmptyArgumentSerializer())
         register<VectorArgument>("vec3", EmptyArgumentSerializer())
+        register("entity", EntityArgumentSerializer())
+        register<GameProfileArgument>("game_profile", EmptyArgumentSerializer())
     }
 
     operator fun get(key: Key) = BY_NAME[key]

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/minecraft/EntityArgumentSerializer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/serializer/minecraft/EntityArgumentSerializer.kt
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.argument.serializer.minecraft
+
+import io.netty.buffer.ByteBuf
+import org.kryptonmc.krypton.command.argument.serializer.ArgumentSerializer
+import org.kryptonmc.krypton.command.arguments.entities.EntityArgument
+
+/**
+ * A serialiser for [EntityArgument]
+ */
+class EntityArgumentSerializer : ArgumentSerializer<EntityArgument> {
+
+    override fun write(argument: EntityArgument, buf: ByteBuf) {
+        var mask = 0
+
+        if (argument.singleTarget) mask = mask or 0x01
+        if (argument.onlyPlayers) mask = mask or 0x02
+
+        buf.writeByte(mask)
+    }
+
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/GameProfileArgument.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/GameProfileArgument.kt
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.arguments
+
+import com.mojang.brigadier.StringReader
+import com.mojang.brigadier.arguments.ArgumentType
+import com.mojang.brigadier.context.CommandContext
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.command.arguments.entities.EntityArgumentParser
+import org.kryptonmc.krypton.command.arguments.entities.EntityQuery
+import org.kryptonmc.krypton.util.argument
+
+class GameProfileArgument private constructor() : ArgumentType<EntityQuery> {
+
+    override fun parse(reader: StringReader): EntityQuery {
+        if (reader.canRead() && reader.peek() == '@') {
+            reader.skip()
+            val position = reader.cursor
+            return EntityArgumentParser.parse(reader, reader.read(), position, onlyPlayers = true, singleTarget = false)
+        } else {
+            val i = reader.cursor
+
+            while (reader.canRead() && reader.peek() != ' ') {
+                reader.skip()
+            }
+
+            val string: String = reader.string.substring(i, reader.cursor)
+
+            return EntityQuery(playerName = string, args = listOf(), type = EntityQuery.SELECTOR.PLAYER)
+        }
+    }
+
+    companion object {
+
+        fun gameProfile() = GameProfileArgument()
+    }
+
+}
+
+fun CommandContext<Sender>.gameProfileArgument(name: String) = argument<EntityQuery>(name)

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/entities/EntityArgument.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/entities/EntityArgument.kt
@@ -1,0 +1,127 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.arguments.entities
+
+import com.mojang.brigadier.StringReader
+import com.mojang.brigadier.arguments.ArgumentType
+import com.mojang.brigadier.context.CommandContext
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.Component.translatable
+import org.kryptonmc.api.adventure.toMessage
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.util.argument
+
+
+class EntityArgument private constructor(
+    val onlyPlayers: Boolean,
+    val singleTarget: Boolean,
+) :
+    ArgumentType<EntityQuery> {
+
+    override fun parse(reader: StringReader) = if (reader.canRead() && reader.peek() == '@') {
+        reader.skip()
+        if (!reader.canRead()) throw MISSING_SELECTOR.createWithContext(reader)
+        val position = reader.cursor
+        EntityArgumentParser.parse(reader, reader.read(), position, onlyPlayers, singleTarget)
+    } else {
+        val input = reader.readString()
+
+        if (input.matches(PLAYER_NAME_REGEX)) {
+            EntityQuery(
+                playerName = input,
+                type = EntityQuery.SELECTOR.PLAYER,
+                args = listOf()
+            )
+        } else {
+            EntityQuery(args = listOf(), EntityQuery.SELECTOR.UNKNOWN)
+        }
+    }
+
+    override fun getExamples() = EXAMPLES
+
+    companion object {
+
+        private val EXAMPLES = listOf("Player1", "Player2", "@a", "@e", "@r", "@a[gamemode=adventure]")
+        private val PLAYER_NAME_REGEX = Regex("[a-zA-Z0-9_]{1,16}")
+
+
+        /**
+         * @return An argument which can only accept one player
+         */
+        fun player() = EntityArgument(onlyPlayers = true, singleTarget = true)
+
+        /**
+         * @return An argument which can only accept players
+         */
+        fun players() = EntityArgument(onlyPlayers = true, singleTarget = false)
+
+
+        /**
+         * @return An argument which can accept one entity
+         */
+        fun entity() = EntityArgument(onlyPlayers = false, singleTarget = true)
+
+        /**
+         * @return An argument which can accept entities
+         */
+        fun entities() = EntityArgument(onlyPlayers = false, singleTarget = false)
+    }
+
+    data class EntityArg(val name: String, val value: Any, val exclude: Boolean)
+
+}
+
+fun CommandContext<Sender>.entityArgument(name: String) = argument<EntityQuery>(name)
+
+val MISSING_SELECTOR = SimpleCommandExceptionType(translatable("argument.entity.selector.missing").toMessage())
+val UNKNOWN_SELECTOR_EXCEPTION = DynamicCommandExceptionType { e ->
+    translatable(
+        "argument.entity.selector.unknown",
+        listOf(text(e.toString()))
+    ).toMessage()
+}
+val NOT_ALLOWED_EXCEPTION = SimpleCommandExceptionType(translatable("argument.entity.selector.not_allowed").toMessage())
+val UNTERMINATED_EXCEPTION =
+    SimpleCommandExceptionType(translatable("argument.entity.options.unterminated").toMessage())
+val VALUELESS_EXCEPTION = DynamicCommandExceptionType { e ->
+    translatable(
+        "argument.entity.options.valueless",
+        listOf(text(e.toString()))
+    ).toMessage()
+}
+val INVALID_OPTION = DynamicCommandExceptionType { e ->
+    translatable(
+        "argument.entity.options.unknown",
+        listOf(text(e.toString()))
+    ).toMessage()
+}
+val PLAYER_NOT_FOUND = SimpleCommandExceptionType(translatable("argument.entity.notfound.player").toMessage())
+val ENTITY_NOT_FOUND = SimpleCommandExceptionType(translatable("argument.entity.notfound.entity").toMessage())
+val TOO_MANY_ENTITIES = SimpleCommandExceptionType(translatable("argument.entity.toomany").toMessage())
+val TOO_MANY_PLAYERS = SimpleCommandExceptionType(translatable("argument.player.toomany").toMessage())
+val ONLY_FOR_PLAYERS = SimpleCommandExceptionType(translatable("argument.player.entities").toMessage())
+val PLAYER_NOT_EXISTS = SimpleCommandExceptionType(translatable("argument.player.unknown").toMessage())
+val LIMIT_NULL = SimpleCommandExceptionType(translatable("argument.entity.options.limit.toosmall").toMessage())
+val DISTANCE_NEGATIVE =
+    SimpleCommandExceptionType(translatable("argument.entity.options.distance.negative").toMessage())
+val INVALID_SORT_TYPE = DynamicCommandExceptionType { e ->
+    translatable("argument.entity.options.sort.irreversible", listOf(text(e.toString()))).toMessage()
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/entities/EntityArgumentParser.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/entities/EntityArgumentParser.kt
@@ -1,0 +1,123 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.arguments.entities
+
+import com.mojang.brigadier.StringReader
+
+object EntityArgumentParser {
+
+    fun parse(
+        reader: StringReader,
+        operation: Char,
+        position: Int,
+        onlyPlayers: Boolean,
+        singleTarget: Boolean,
+    ) = when (operation) {
+        'p' -> {
+            EntityQuery(listOf(), EntityQuery.SELECTOR.NEAREST_PLAYER)
+        }
+        'e' -> {
+            if (singleTarget) {
+                reader.cursor = 0
+                throw TOO_MANY_ENTITIES.createWithContext(reader)
+            } else if (onlyPlayers) {
+                reader.cursor = 0
+                throw ONLY_FOR_PLAYERS.createWithContext(reader)
+            }
+            if (reader.canRead() && reader.peek() == '[') {
+                reader.skip()
+                EntityQuery(parseArguments(reader), EntityQuery.SELECTOR.ALL_ENTITIES)
+            } else {
+                EntityQuery(listOf(), EntityQuery.SELECTOR.ALL_ENTITIES)
+            }
+        }
+        'r' -> {
+            EntityQuery(listOf(), EntityQuery.SELECTOR.RANDOM_PLAYER)
+        }
+        'a' -> {
+            if (singleTarget) {
+                reader.cursor = 0
+                throw TOO_MANY_PLAYERS.createWithContext(reader)
+            }
+            if (reader.canRead() && reader.peek() == '[') {
+                reader.skip()
+                EntityQuery(parseArguments(reader), EntityQuery.SELECTOR.ALL_PLAYERS)
+            } else {
+                EntityQuery(listOf(), EntityQuery.SELECTOR.ALL_PLAYERS)
+            }
+        }
+        's' -> {
+            EntityQuery(listOf(), EntityQuery.SELECTOR.EXECUTOR)
+        }
+        else -> {
+            reader.cursor = position
+            throw UNKNOWN_SELECTOR_EXCEPTION.createWithContext(reader, "@$operation")
+        }
+    }
+
+    private fun parseArguments(
+        reader: StringReader,
+    ): List<EntityArgument.EntityArg> {
+        reader.skipWhitespace()
+        val args = mutableListOf<EntityArgument.EntityArg>()
+        while (reader.canRead() && reader.peek() != ']') {
+            reader.skipWhitespace()
+            val position = reader.cursor
+            val option = reader.readString()
+            if (option !in EntityArguments.ARGUMENTS) throw INVALID_OPTION.createWithContext(reader, option)
+            reader.skipWhitespace()
+            if (reader.canRead() && reader.peek() == '=') {
+                reader.skip()
+                reader.skipWhitespace()
+                val exclude = if (reader.peek() == '!') {
+                    reader.skip()
+                    true
+                } else false
+                val value = reader.readString()
+                args += EntityArgument.EntityArg(option, value, exclude)
+
+                reader.skipWhitespace()
+                if (!reader.canRead()) {
+                    continue
+                }
+
+                if (reader.peek() == ',') {
+                    reader.skip()
+                    continue
+                }
+
+                if (reader.peek() != ']') {
+                    throw UNTERMINATED_EXCEPTION.createWithContext(reader)
+                }
+                break
+            }
+
+            reader.cursor = position
+            throw VALUELESS_EXCEPTION.createWithContext(reader, option)
+        }
+        if (reader.canRead()) {
+            reader.skip()
+        } else {
+            throw UNTERMINATED_EXCEPTION.createWithContext(reader)
+        }
+        return args.toList()
+    }
+
+
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/entities/EntityArguments.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/entities/EntityArguments.kt
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.arguments.entities
+
+object EntityArguments {
+
+    val SELECTOR_ALL = listOf("@p", "@r", "@a", "@e", "@s")
+    val SELECTOR_PLAYERS = listOf("@p", "@r", "@a", "@s")
+    val SELECTOR_PLAYERS_SINGLE = listOf("@p", "@r", "@s")
+    val ARGUMENTS = listOf(
+        "x", "y", "z",
+        "distance", "dx", "dy", "dz",
+        "scores", "tag", "team", "limit", "sort", "level", "gamemode", "name",
+        "x_rotation", "y_rotation", "type", "nbt", "advancements", "predicate"
+    )
+    val EXCLUDE_ARGUMENTS = listOf(
+        "team", "tag", "gamemode", "name", "predicate"
+    )
+
+    enum class Sorter {
+
+        /**
+         * Sort by increasing distance
+         */
+        NEAREST,
+
+        /**
+         * Sort by decreasing distance
+         */
+        FURTHEST,
+
+        /**
+         * Sort randomly
+         */
+        RANDOM,
+
+        /**
+         * Sort by time created
+         */
+        ARBITRARY;
+
+        companion object {
+
+            /**
+             * Get the sort candidate from the name
+             */
+            fun fromName(name: String) = values().firstOrNull { it.name == name.uppercase() }
+
+        }
+    }
+
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/entities/EntityQuery.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/entities/EntityQuery.kt
@@ -1,0 +1,317 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.arguments.entities
+
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.Component.translatable
+import org.kryptonmc.api.adventure.toMessage
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.api.world.Gamemode
+import org.kryptonmc.krypton.KryptonServer
+import org.kryptonmc.krypton.auth.GameProfile
+import org.kryptonmc.krypton.command.BrigadierExceptions
+import org.kryptonmc.krypton.entity.KryptonEntity
+import org.kryptonmc.krypton.entity.player.KryptonPlayer
+import org.kryptonmc.krypton.util.toIntRange
+
+/**
+ * Documentation [TODO]
+ */
+class EntityQuery(
+    private val args: List<EntityArgument.EntityArg>,
+    val type: SELECTOR,
+    private val playerName: String = ""
+) {
+    fun getEntities(source: KryptonPlayer) = when (type) {
+        SELECTOR.RANDOM_PLAYER -> {
+            listOf(source.server.players.random())
+        }
+        SELECTOR.ALL_PLAYERS -> {
+            if (args.isNotEmpty()) {
+                val entities = applyArguments((source.server.players + source.world.entities).toList(), source)
+                if (entities.isEmpty()) throw PLAYER_NOT_FOUND.create()
+                entities
+            } else {
+                source.server.players
+            }
+        }
+        SELECTOR.EXECUTOR -> listOf(source)
+        SELECTOR.ALL_ENTITIES -> {
+            if (args.isNotEmpty()) {
+                val entities = applyArguments((source.server.players + source.world.entities).toList(), source)
+                if (entities.isEmpty()) throw ENTITY_NOT_FOUND.create()
+                entities
+            } else {
+                (source.server.players + source.world.entities).toList()
+            }
+        }
+        SELECTOR.NEAREST_PLAYER -> {
+            var currentNearest = source.server.players[0]
+            for (player in source.server.players) {
+                if (player.distance(source) < currentNearest.distance(source)) currentNearest = player
+            }
+            listOf(currentNearest)
+        }
+        SELECTOR.PLAYER -> listOf(source.server.player(playerName) ?: throw PLAYER_NOT_EXISTS.create())
+        SELECTOR.UNKNOWN -> throw UNKNOWN_SELECTOR_EXCEPTION.create("")
+    }
+
+    fun getEntity(source: KryptonPlayer): KryptonEntity = getEntities(source)[0]
+
+    fun getPlayers(sender: Sender): List<KryptonPlayer> {
+        val server = sender.server as KryptonServer
+        if (sender is KryptonPlayer) {
+            if (playerName.isNotEmpty()) return listOf(server.player(playerName) ?: throw PLAYER_NOT_FOUND.create())
+            return getEntities(sender).map { if (it !is KryptonPlayer) throw UnsupportedOperationException("You cannot call .getPlayers() if there is an entity in the arguments") else it }
+        } else {
+            return listOf(server.player(playerName) ?: throw PLAYER_NOT_FOUND.create())
+        }
+    }
+
+    fun getProfiles(sender: Sender): List<GameProfile> {
+        val server = sender.server as KryptonServer
+        return if (sender is KryptonPlayer) {
+            if (playerName.isNotEmpty()) {
+                listOf(server.playerManager.userCache.getProfileByName(playerName) ?: throw PLAYER_NOT_FOUND.create())
+            } else {
+                getPlayers(sender).map { it.profile }
+            }
+        } else {
+            if (playerName.isNotEmpty()) {
+                listOf(server.playerManager.userCache.getProfileByName(playerName) ?: throw PLAYER_NOT_FOUND.create())
+            } else {
+                listOf()
+            }
+        }
+    }
+
+    private fun applyArguments(originalEntities: List<KryptonEntity>, source: KryptonPlayer): List<KryptonEntity> {
+        var entities = originalEntities
+        var differenceX = 0
+        var differenceY = 0
+        var differenceZ = 0
+        for ((option, value, exclude) in args) {
+            when (option) {
+                "dx" -> {
+                    checkInt(value.toString())
+                    differenceX = value.toString().toInt()
+                }
+                "dy" -> {
+                    checkInt(value.toString())
+                    differenceY = value.toString().toInt()
+                }
+                "dz" -> {
+                    checkInt(value.toString())
+                    differenceZ = value.toString().toInt()
+                }
+                "x" -> {
+                    checkInt(value.toString())
+                    entities = entities.filter {
+                        applyDifference(differenceX, value, it.location.blockX)
+                    }
+                }
+                "y" -> {
+                    checkInt(value.toString())
+                    entities = entities.filter {
+                        applyDifference(differenceY, value, it.location.blockY)
+                    }
+                }
+                "z" -> {
+                    checkInt(value.toString())
+                    entities = entities.filter {
+                        applyDifference(differenceZ, value, it.location.blockZ)
+                    }
+                }
+                "distance" -> {
+                    checkIntOrRange(value.toString())
+                    entities = if (value.toString().startsWith("..")) {
+                        val distance = value.toString().replace("..", "").toInt()
+                        entities.filter {
+                            it.distance(source) <= distance
+                        }
+                    } else if (!value.toString().contains("..")) {
+                        checkInt(value.toString())
+                        entities.filter {
+                            val int = it.distance(source).toInt()
+                            if (int < 0) throw DISTANCE_NEGATIVE.create()
+                            int == value.toString().toInt()
+                        }
+                    } else {
+                        val range = value.toString().toIntRange()
+                        entities.filter {
+                            it.distance(source) >= range!!.first && it.distance(source) <= range.last
+                        }
+                    }
+                }
+                "scores" -> {
+                    notImplemented("scores")
+                }
+                "tag" -> {
+                    notImplemented("tag")
+                }
+                "team" -> {
+                    notImplemented("team")
+                }
+                "level" -> {
+                    notImplemented("level")
+                }
+                "gamemode" -> {
+                    entities = entities.filter {
+                        if (it !is KryptonPlayer) return@filter true
+                        if (exclude) {
+                            it.gamemode != Gamemode.fromName(value.toString())
+                        } else {
+                            it.gamemode == Gamemode.fromName(value.toString())
+                        }
+                    }
+                }
+                "name" -> {
+                    entities = entities.filter {
+                        if (exclude) it.name != value else it.name == value
+                    }
+                }
+                "x_rotation" -> {
+                    checkIntOrRange(value.toString())
+                    entities = if (value.toString().startsWith("..")) {
+                        val pitch = value.toString().replace("..", "").toInt()
+                        entities.filter {
+                            it.location.pitch <= pitch
+                        }
+                    } else if (!value.toString().contains("..")) {
+                        entities.filter {
+                            it.location.pitch.toInt() == value.toString().toInt()
+                        }
+                    } else {
+                        val range = value.toString().toIntRange()
+                        entities.filter {
+                            it.location.pitch >= range!!.first && it.location.pitch <= range.last
+                        }
+                    }
+                }
+                "y_rotation" -> {
+                    checkIntOrRange(value.toString())
+                    entities = if (value.toString().startsWith("..")) {
+                        val yaw = value.toString().replace("..", "").toInt()
+                        entities.filter {
+                            it.location.yaw <= yaw
+                        }
+                    } else if (!value.toString().contains("..")) {
+                        entities.filter {
+                            it.location.yaw.toInt() == value.toString().toInt()
+                        }
+                    } else {
+                        val range = value.toString().toIntRange()
+                        entities.filter {
+                            it.location.yaw >= range!!.first && it.location.yaw <= range.last
+                        }
+                    }
+                }
+                "type" -> {
+                    notImplemented("type")
+                }
+                "nbt" -> {
+                    notImplemented("nbt")
+                }
+                "advancements" -> {
+                    notImplemented("advancements")
+                }
+                "predicate" -> {
+                    notImplemented("predicate")
+                }
+                "sort" -> {
+                    val sorter = EntityArguments.Sorter.fromName(value.toString())
+                        ?: throw INVALID_SORT_TYPE.create(value)
+                    entities = when (sorter) {
+                        EntityArguments.Sorter.NEAREST -> entities.sortedBy { it.distance(source) }
+                        EntityArguments.Sorter.FURTHEST -> entities.sortedByDescending { it.distance(source) }
+                        EntityArguments.Sorter.RANDOM -> entities.shuffled()
+                        EntityArguments.Sorter.ARBITRARY -> entities.sortedBy { it.ticksLived }
+                    }
+                }
+                "limit" -> {
+                    checkInt(value.toString())
+                    val limit = value.toString().toInt()
+                    if (limit <= 0) throw LIMIT_NULL.create()
+                    entities = if (entities.size > limit) entities.subList(0, limit - 1) else entities
+                }
+                else -> {
+                    throw UnsupportedOperationException("Invalid option")
+                }
+            }
+        }
+        return entities
+    }
+
+    private fun applyDifference(difference: Int, value: Any, blockCoordinate: Int) = if (difference != 0) {
+        val min = value.toString().toInt()
+        val max = min + difference
+        blockCoordinate in min..max
+    } else {
+        blockCoordinate == value.toString().toInt()
+    }
+
+    private fun notImplemented(option: String) {
+        throw DynamicCommandExceptionType { a ->
+            text("Not yet implemented: $a").toMessage()
+        }.create(option)
+    }
+
+    private fun checkInt(string: String) =
+        string.toIntOrNull() ?: throw BrigadierExceptions.readerExpectedInt().create()
+
+    private fun checkIntOrRange(string: String) {
+        if (string.toIntOrNull() != null) return
+        if (string.startsWith("..") && string.substring(2).toIntOrNull() != null) return
+        if (string.contains("..") && string.toIntRange() != null) return
+        throw SimpleCommandExceptionType(translatable("argument.range.empty").toMessage()).create()
+    }
+
+    enum class SELECTOR {
+
+        RANDOM_PLAYER,
+        ALL_PLAYERS,
+        EXECUTOR,
+        ALL_ENTITIES,
+        NEAREST_PLAYER,
+        PLAYER,
+        UNKNOWN;
+
+        companion object {
+
+            /**
+             * Get the target selector from it's short name
+             * you can find these at the [Minecraft Wiki](https://minecraft.fandom.com/wiki/Target_selectors)
+             */
+            fun fromChar(selector: Char) = when (selector) {
+                'p' -> NEAREST_PLAYER
+                'r' -> RANDOM_PLAYER
+                'a' -> ALL_PLAYERS
+                'e' -> ALL_ENTITIES
+                's' -> EXECUTOR
+                else -> UNKNOWN
+            }
+        }
+
+    }
+
+}
+
+

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/BanCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/BanCommand.kt
@@ -1,0 +1,110 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.arguments.StringArgumentType.string
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.Component.translatable
+import org.kryptonmc.api.command.PermissionLevel
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.KryptonServer
+import org.kryptonmc.krypton.auth.GameProfile
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.arguments.GameProfileArgument
+import org.kryptonmc.krypton.command.arguments.entities.EntityQuery
+import org.kryptonmc.krypton.command.arguments.gameProfileArgument
+import org.kryptonmc.krypton.command.permission
+import org.kryptonmc.krypton.entity.player.KryptonPlayer
+import org.kryptonmc.krypton.server.ban.BanEntry
+import org.kryptonmc.krypton.server.ban.BannedPlayerEntry
+import org.kryptonmc.krypton.util.argument
+import org.kryptonmc.krypton.util.toComponent
+
+object BanCommand : InternalCommand {
+
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        dispatcher.register(
+            literal<Sender>("ban")
+                .permission("krypton.command.ban", PermissionLevel.LEVEL_3)
+                .then(
+                    argument<Sender, EntityQuery>("targets", GameProfileArgument.gameProfile())
+                        .executes {
+                            ban(
+                                it.gameProfileArgument("targets").getProfiles(it.source),
+                                server = it.source.server as KryptonServer,
+                                sender = it.source
+                            )
+                        1
+                    }
+                    .then(argument<Sender, String>("reason", string())
+                        .executes {
+                            val reason = it.argument<String>("reason")
+                            ban(
+                                it.gameProfileArgument("targets").getProfiles(it.source),
+                                server = it.source.server as KryptonServer,
+                                sender = it.source,
+                                reason = reason
+                            )
+                            1
+                        })
+                )
+        )
+    }
+
+    private fun ban(
+        profiles: List<GameProfile>,
+        reason: String = "Banned by operator.",
+        server: KryptonServer,
+        sender: Sender
+    ) {
+        for (target in profiles) {
+            if (!server.playerManager.bannedPlayers.contains(target)) {
+                val entry = BannedPlayerEntry(target, reason = reason)
+                server.playerManager.bannedPlayers += entry
+                if (server.player(target.uuid) != null) kick(entry, server.player(target.uuid)!!)
+                sender.sendMessage(translatable("commands.ban.success", listOf(text(target.name), text(reason))))
+                logBan(target.name, sender.name, reason, server)
+            }
+        }
+    }
+
+    private fun kick(entry: BannedPlayerEntry, player: KryptonPlayer) {
+        val text = translatable("multiplayer.disconnect.banned.reason", listOf(entry.reason.toComponent()))
+        if (entry.expiryDate != null) text.append(
+            translatable(
+                "multiplayer.disconnect.banned.expiration", listOf(
+                    BanEntry.DATE_FORMAT.format(entry.expiryDate).toComponent()
+                )
+            )
+        )
+        player.disconnect(text)
+    }
+
+    private fun logBan(target: String, source: String, reason: String, server: KryptonServer) =
+        server.console.sendMessage(
+            translatable(
+                "commands.banlist.entry",
+                listOf(target.toComponent(), source.toComponent(), reason.toComponent())
+            )
+        )
+
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/BanIpCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/BanIpCommand.kt
@@ -1,0 +1,120 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.arguments.StringArgumentType.string
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
+import net.kyori.adventure.text.Component.translatable
+import org.kryptonmc.api.adventure.toMessage
+import org.kryptonmc.api.command.PermissionLevel
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.KryptonServer
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.permission
+import org.kryptonmc.krypton.server.ban.BanEntry
+import org.kryptonmc.krypton.server.ban.BannedIpEntry
+import org.kryptonmc.krypton.util.argument
+import org.kryptonmc.krypton.util.stringify
+import org.kryptonmc.krypton.util.toComponent
+
+object BanIpCommand : InternalCommand {
+
+    private val ALREADY_BANNED_EXCEPTION = SimpleCommandExceptionType(translatable("commands.banip.failed").toMessage())
+    val PATTERN =
+        Regex("^([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])$")
+
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        dispatcher.register(
+            literal<Sender>("ban-ip")
+                .permission("krypton.command.banip", PermissionLevel.LEVEL_3)
+                .then(
+                    argument<Sender, String>("target", string())
+                        .executes {
+                            banIp(it.source.server as KryptonServer, it.argument("target"), it.source)
+                            1
+                }
+                .then(argument<Sender, String>("reason", string())
+                    .executes {
+                        banIp(
+                            it.source.server as KryptonServer,
+                            it.argument("target"),
+                            it.source,
+                            it.argument("reason")
+                        )
+                        1
+                    })
+            )
+        )
+    }
+
+    private fun banIp(server: KryptonServer, target: String, sender: Sender, reason: String = "Banned by operator") {
+        if (target.matches(PATTERN)) {
+            if (server.playerManager.bannedIps.contains(target)) {
+                throw ALREADY_BANNED_EXCEPTION.create()
+            } else {
+                val entry = BannedIpEntry(target, reason = reason)
+                server.playerManager.bannedIps += entry
+                sender.sendMessage(
+                    translatable(
+                        "commands.banip.success",
+                        listOf(target.toComponent(), reason.toComponent())
+                    )
+                )
+                logBan(target, sender.name, reason, server)
+            }
+        } else if (server.player(target) != null) {
+            val player = server.player(target)!!
+            val entry = BannedIpEntry(player.address.stringify(), reason = reason)
+            if (server.playerManager.bannedIps.contains(entry.key)) {
+                throw ALREADY_BANNED_EXCEPTION.create()
+            } else {
+                server.playerManager.bannedIps += entry
+                val text = translatable("multiplayer.disconnect.banned_ip.reason", listOf(entry.reason.toComponent()))
+                if (entry.expiryDate != null) text.append(
+                    translatable(
+                        "multiplayer.disconnect.banned.expiration", listOf(
+                            BanEntry.DATE_FORMAT.format(entry.expiryDate).toComponent()
+                        )
+                    )
+                )
+                player.disconnect(text)
+                sender.sendMessage(
+                    translatable(
+                        "commands.banip.success",
+                        listOf(target.toComponent(), entry.reason.toComponent())
+                    )
+                )
+                logBan(target, sender.name, reason, server)
+            }
+        } else {
+            sender.sendMessage(translatable("commands.banip.invalid"))
+        }
+    }
+
+    private fun logBan(target: String, source: String, reason: String, server: KryptonServer) =
+        server.console.sendMessage(
+            translatable(
+                "commands.banlist.entry",
+                listOf(target.toComponent(), source.toComponent(), reason.toComponent())
+            )
+        )
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/DeopCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/DeopCommand.kt
@@ -1,0 +1,71 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.Component.translatable
+import org.kryptonmc.api.adventure.toMessage
+import org.kryptonmc.api.command.PermissionLevel
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.KryptonServer
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.arguments.GameProfileArgument
+import org.kryptonmc.krypton.command.arguments.entities.EntityQuery
+import org.kryptonmc.krypton.command.arguments.gameProfileArgument
+import org.kryptonmc.krypton.command.permission
+import org.kryptonmc.krypton.command.suggest
+import org.kryptonmc.krypton.util.toComponent
+
+object DeopCommand : InternalCommand {
+
+    private val ALREADY_DEOPPED_EXCEPTION = SimpleCommandExceptionType(translatable("commands.deop.failed").toMessage())
+
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        dispatcher.register(
+            literal<Sender>("deop")
+                .permission("krypton.command.deop", PermissionLevel.LEVEL_3)
+                .then(
+                    argument<Sender, EntityQuery>("targets", GameProfileArgument.gameProfile())
+                        .suggests { context, builder -> builder.suggest((context.source.server as KryptonServer).playerManager.ops.map { it.key.name }) }
+                        .executes {
+                            val targets = it.gameProfileArgument("targets").getProfiles(it.source)
+                            val server = it.source.server as KryptonServer
+                            for (target in targets) {
+                                val ops = server.playerManager.ops
+                                if (ops.contains(target)) {
+                                    server.playerManager.removeFromOperators(target)
+                                    it.source.sendMessage(
+                                        Component.translatable(
+                                            "commands.deop.success",
+                                            listOf(target.name.toComponent())
+                                        )
+                                    )
+                                } else {
+                                    throw ALREADY_DEOPPED_EXCEPTION.create()
+                                }
+                            }
+                            1
+                        })
+        )
+    }
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/DifficultyCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/DifficultyCommand.kt
@@ -1,0 +1,72 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import net.kyori.adventure.text.Component.translatable
+import org.kryptonmc.api.command.PermissionLevel
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.api.world.Difficulty
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.permission
+import org.kryptonmc.krypton.entity.player.KryptonPlayer
+
+object DifficultyCommand : InternalCommand {
+
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        val command = literal<Sender>("difficulty")
+            .permission("krypton.command.difficulty", PermissionLevel.LEVEL_2)
+            .executes {
+                val sender = it.source as? KryptonPlayer ?: return@executes 1
+                sender.sendMessage(
+                    translatable(
+                        "commands.difficulty.query",
+                        listOf(translatable("options.difficulty.${sender.world.difficulty.name.lowercase()}"))
+                    )
+                )
+                1
+            }
+        for (value in Difficulty.values()) {
+            command
+                .then(literal<Sender>(value.name.lowercase())
+                    .executes {
+                        val sender = it.source as? KryptonPlayer ?: return@executes 1
+                        if (sender.world.difficulty == value) {
+                            sender.sendMessage(
+                                translatable(
+                                    "commands.difficulty.failure",
+                                    listOf(translatable("options.difficulty.${value.name.lowercase()}"))
+                                )
+                            )
+                        } else {
+                            sender.world.difficulty = value
+                            sender.sendMessage(
+                                translatable(
+                                    "commands.difficulty.success",
+                                    listOf(translatable("options.difficulty.${value.name.lowercase()}"))
+                                ),
+                            )
+                        }
+                        1
+                    })
+        }
+        dispatcher.register(command)
+    }
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/GamemodeCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/GamemodeCommand.kt
@@ -19,36 +19,92 @@
 package org.kryptonmc.krypton.command.commands
 
 import com.mojang.brigadier.CommandDispatcher
-import com.mojang.brigadier.arguments.StringArgumentType
+import com.mojang.brigadier.arguments.StringArgumentType.string
 import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
 import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
+import com.mojang.brigadier.context.CommandContext
+import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.Component.translatable
+import org.kryptonmc.api.command.PermissionLevel
 import org.kryptonmc.api.command.Sender
 import org.kryptonmc.api.world.Gamemode
-import org.kryptonmc.krypton.KryptonServer
 import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.arguments.entities.EntityArgument
+import org.kryptonmc.krypton.command.arguments.entities.EntityQuery
+import org.kryptonmc.krypton.command.arguments.entities.entityArgument
+import org.kryptonmc.krypton.command.permission
 import org.kryptonmc.krypton.entity.player.KryptonPlayer
-import org.kryptonmc.krypton.packet.out.play.PacketOutPlayerInfo
-import org.kryptonmc.krypton.packet.out.play.PacketOutPlayerInfo.PlayerAction.UPDATE_GAMEMODE
 import org.kryptonmc.krypton.util.argument
 
-class GamemodeCommand(private val server: KryptonServer) : InternalCommand {
+object GamemodeCommand : InternalCommand {
 
     override fun register(dispatcher: CommandDispatcher<Sender>) {
-        val node = literal<Sender>("gamemode")
-        Gamemode.values().forEach { mode ->
-            node.then(argument<Sender, String>(mode.name.lowercase(), StringArgumentType.string())
-                .executes {
-                    updateGameMode(it.source as? KryptonPlayer ?: return@executes 1, Gamemode.valueOf(it.argument<String>(mode.name.lowercase()).uppercase()))
-                    1
-                })
+        val command = literal<Sender>("gamemode")
+            .permission("krypton.command.gamemode", PermissionLevel.LEVEL_2)
+        for (gamemode in Gamemode.values()) {
+            command
+                .then(
+                    literal<Sender>(gamemode.name.lowercase())
+                        .executes {
+                            gameModeArgument(it, gamemode)
+                        }
+                        .then(argument<Sender, EntityQuery>("targets", EntityArgument.players())
+                            .executes {
+                                targetArgument(it, gamemode)
+                            })
+                )
         }
-        dispatcher.register(node)
+
+        command
+            .then(argument<Sender, String>("gamemode", string())
+                .executes {
+                    val gamemode = Gamemode.fromShortName(it.argument("gamemode"))
+                        ?: Gamemode.fromId(it.argument<String>("gamemode").toIntOrNull() ?: return@executes 1)
+                        ?: return@executes 1
+                    gameModeArgument(it, gamemode)
+                }
+                .then(argument<Sender, EntityQuery>("targets", EntityArgument.players())
+                    .executes {
+
+                        val gamemode = Gamemode.fromShortName(it.argument("gamemode")) ?: Gamemode.fromId(
+                            it.argument<String>("gamemode").toIntOrNull() ?: return@executes 1
+                        ) ?: return@executes 1
+                        targetArgument(it, gamemode)
+                    })
+            )
+
+        dispatcher.register(command)
     }
 
-    private fun updateGameMode(player: KryptonPlayer, mode: Gamemode) {
-        player.gamemode = mode
-        server.playerManager.sendToAll(PacketOutPlayerInfo(UPDATE_GAMEMODE, player))
-        player.sendMessage(translatable("commands.gamemode.success.self", listOf(translatable("gameMode.${mode.name.lowercase()}"))))
+    private fun gameModeArgument(context: CommandContext<Sender>, gamemode: Gamemode): Int {
+        val sender = context.source as? KryptonPlayer ?: return 1
+        updateGameMode(listOf(sender), gamemode, sender)
+        return 1
     }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun targetArgument(context: CommandContext<Sender>, gamemode: Gamemode): Int {
+        val sender = context.source as? KryptonPlayer ?: return 1
+        val entities = context.entityArgument("targets").getPlayers(sender)
+
+        updateGameMode(entities, gamemode, sender)
+        return 1
+    }
+
+    private fun updateGameMode(entities: List<KryptonPlayer>, mode: Gamemode, sender: KryptonPlayer) {
+        for (entity in entities) {
+            entity.gamemode = mode
+            sender.sendMessage(
+                if (sender == entity) translatable(
+                    "gameMode.changed",
+                    listOf(translatable("gameMode.${mode.name.lowercase()}"))
+                ) else translatable(
+                    "commands.gamemode.success.other",
+                    listOf(text(entity.name), translatable("gameMode.${mode.name.lowercase()}"))
+                )
+            )
+        }
+
+    }
+
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/GameruleCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/GameruleCommand.kt
@@ -1,0 +1,88 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.arguments.BoolArgumentType
+import com.mojang.brigadier.arguments.IntegerArgumentType
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
+import net.kyori.adventure.text.Component.translatable
+import org.kryptonmc.api.command.PermissionLevel
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.api.world.rule.GameRule
+import org.kryptonmc.api.world.rule.GameRules
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.permission
+import org.kryptonmc.krypton.entity.player.KryptonPlayer
+import org.kryptonmc.krypton.util.argument
+import org.kryptonmc.krypton.util.toComponent
+
+object GameruleCommand : InternalCommand {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        val command = literal<Sender>("gamerule")
+            .permission("krypton.command.gamerule", PermissionLevel.LEVEL_2)
+        for ((_, rule) in GameRules.rules) {
+            val gameRule = literal<Sender>(rule.name)
+                .executes {
+                    val sender = it.source as? KryptonPlayer ?: return@executes 1
+                    sender.sendMessage(
+                        translatable(
+                            "commands.gamerule.query",
+                            listOf(rule.name.toComponent(), sender.world.gameRules[rule].toString().toComponent())
+                        )
+                    )
+                    1
+                }
+            if (rule.default is Boolean) {
+                gameRule.then(argument<Sender, Boolean>("value", BoolArgumentType.bool())
+                    .executes {
+                        val sender = it.source as? KryptonPlayer ?: return@executes 1
+                        val value = it.argument<Boolean>("value")
+                        sender.world.gameRules[rule as GameRule<Boolean>] = value
+                        sender.sendMessage(
+                            translatable(
+                                "commands.gamerule.set",
+                                listOf(rule.name.toComponent(), value.toString().toComponent())
+                            )
+                        )
+                        1
+                    })
+            } else if (rule.default is Int) {
+                gameRule.then(argument<Sender, Int>("value", IntegerArgumentType.integer())
+                    .executes {
+                        val sender = it.source as? KryptonPlayer ?: return@executes 1
+                        val value = it.argument<Int>("value")
+                        sender.world.gameRules[rule as GameRule<Int>] = value
+                        sender.sendMessage(
+                            translatable(
+                                "commands.gamerule.set",
+                                listOf(rule.name.toComponent(), value.toString().toComponent())
+                            )
+                        )
+                        1
+                    })
+            }
+            command.then(gameRule)
+        }
+        dispatcher.register(command)
+    }
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/KickCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/KickCommand.kt
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.arguments.StringArgumentType.string
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
+import org.kryptonmc.api.command.PermissionLevel
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.arguments.entities.EntityArgument
+import org.kryptonmc.krypton.command.arguments.entities.EntityQuery
+import org.kryptonmc.krypton.command.arguments.entities.entityArgument
+import org.kryptonmc.krypton.command.permission
+import org.kryptonmc.krypton.util.argument
+
+object KickCommand : InternalCommand {
+
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        dispatcher.register(
+            literal<Sender>("kick")
+                .permission("krypton.command.kick", PermissionLevel.LEVEL_3)
+                .then(
+                    argument<Sender, EntityQuery>("targets", EntityArgument.players())
+                        .executes {
+                            val players = it.entityArgument("targets").getPlayers(it.source)
+                            for (player in players) {
+                                player.kick()
+                            }
+                            1
+                        }
+                        .then(argument<Sender, String>("reason", string())
+                            .executes {
+                                val reason = it.argument<String>("reason")
+                                val players = it.entityArgument("targets").getPlayers(it.source)
+                                for (player in players) {
+                                    player.kick(reason)
+                                }
+                                1
+                            })
+                )
+        )
+    }
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/KickCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/KickCommand.kt
@@ -22,6 +22,9 @@ import com.mojang.brigadier.CommandDispatcher
 import com.mojang.brigadier.arguments.StringArgumentType.string
 import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
 import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.Component.translatable
 import org.kryptonmc.api.command.PermissionLevel
 import org.kryptonmc.api.command.Sender
 import org.kryptonmc.krypton.command.InternalCommand
@@ -42,7 +45,7 @@ object KickCommand : InternalCommand {
                         .executes {
                             val players = it.entityArgument("targets").getPlayers(it.source)
                             for (player in players) {
-                                player.kick()
+                                player.disconnect(translatable("multiplayer.disconnect.kicked"))
                             }
                             1
                         }
@@ -51,7 +54,7 @@ object KickCommand : InternalCommand {
                                 val reason = it.argument<String>("reason")
                                 val players = it.entityArgument("targets").getPlayers(it.source)
                                 for (player in players) {
-                                    player.kick(reason)
+                                    player.disconnect(translatable("multiplayer.disconnect.kicked").append(text(" Reason: $reason")))
                                 }
                                 1
                             })

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/ListCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/ListCommand.kt
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.Component.translatable
+import org.kryptonmc.api.command.PermissionLevel
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.KryptonServer
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.permission
+import org.kryptonmc.krypton.entity.player.KryptonPlayer
+
+object ListCommand : InternalCommand {
+
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        dispatcher.register(
+            literal<Sender>("list")
+                .permission("krypton.command.list", PermissionLevel.LEVEL_1)
+                .executes {
+                    sendNames(it.source, it.source.server as KryptonServer)
+                    1
+                }
+                .then(
+                    literal<Sender>("uuids")
+                    .executes {
+                        sendNamesWithUUID(it.source, it.source.server as KryptonServer)
+                        1
+                    })
+        )
+    }
+
+    private fun sendNames(sender: Sender, server: KryptonServer) {
+        val names = server.players.map(KryptonPlayer::name)
+        sender.sendMessage(
+            translatable(
+                "commands.list.players",
+                listOf(text(names.size), text(server.status.maxPlayers), text(names.joinToString(separator = "\n")))
+            )
+        )
+    }
+
+    private fun sendNamesWithUUID(sender: Sender, server: KryptonServer) {
+        val names = server.players.map { it.name + " (${it.uuid})" }
+        sender.sendMessage(
+            translatable(
+                "commands.list.players",
+                listOf(text(names.size), text(server.status.maxPlayers), text(names.joinToString(separator = "\n")))
+            )
+        )
+    }
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/MeCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/MeCommand.kt
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.arguments.StringArgumentType.string
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.Component.translatable
+import org.kryptonmc.api.command.PermissionLevel
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.permission
+import org.kryptonmc.krypton.entity.player.KryptonPlayer
+import org.kryptonmc.krypton.util.argument
+
+object MeCommand : InternalCommand {
+
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        dispatcher.register(
+            literal<Sender>("me")
+                .permission("krypton.command.list", PermissionLevel.LEVEL_1)
+                .then(
+                    argument<Sender, String>("action", string())
+                        .executes {
+                            val sender = it.source as? KryptonPlayer ?: return@executes 1
+                            sender.server.broadcast(
+                                translatable(
+                                    "chat.type.emote",
+                                listOf(text(sender.name), text(it.argument<String>("action")))
+                            )
+                        )
+                        1
+                    })
+        )
+    }
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/MessageCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/MessageCommand.kt
@@ -1,0 +1,72 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.arguments.StringArgumentType.string
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.Component.translatable
+import org.kryptonmc.api.command.PermissionLevel
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.arguments.entities.EntityArgument
+import org.kryptonmc.krypton.command.arguments.entities.EntityQuery
+import org.kryptonmc.krypton.command.arguments.entities.entityArgument
+import org.kryptonmc.krypton.command.permission
+import org.kryptonmc.krypton.entity.player.KryptonPlayer
+import org.kryptonmc.krypton.util.argument
+
+object MessageCommand : InternalCommand {
+
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        val messageCommand = dispatcher.register(
+            literal<Sender>("msg")
+                .permission("krypton.command.msg", PermissionLevel.LEVEL_1)
+                .then(
+                    argument<Sender, EntityQuery>("player", EntityArgument.player())
+                        .then(
+                            argument<Sender, String>("message", string())
+                                .executes {
+                                    val source =
+                                        if (it.source !is KryptonPlayer) return@executes 1 else it.source as KryptonPlayer
+                                    val player = it.entityArgument("player").getPlayers(source)[0]
+                                    val message = it.argument<String>("message")
+                                source.sendMessage(
+                                    translatable(
+                                        "commands.message.display.outgoing",
+                                        listOf(text(player.name), text(message))
+                                    )
+                                )
+                                player.sendMessage(
+                                    translatable(
+                                        "commands.message.display.incoming",
+                                        listOf(text(source.name), text(message))
+                                    )
+                                )
+                                1
+                            })
+                )
+        )
+
+        dispatcher.register(literal<Sender>("tell").redirect(messageCommand))
+        dispatcher.register(literal<Sender>("w").redirect(messageCommand))
+    }
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/OpCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/OpCommand.kt
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
+import net.kyori.adventure.text.Component.translatable
+import org.kryptonmc.api.adventure.toMessage
+import org.kryptonmc.api.command.PermissionLevel
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.KryptonServer
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.arguments.GameProfileArgument
+import org.kryptonmc.krypton.command.arguments.entities.EntityQuery
+import org.kryptonmc.krypton.command.arguments.gameProfileArgument
+import org.kryptonmc.krypton.command.permission
+import org.kryptonmc.krypton.util.toComponent
+
+object OpCommand : InternalCommand {
+
+    private val ALREADY_OPPED_EXCEPTION = SimpleCommandExceptionType(translatable("commands.op.failed").toMessage())
+
+
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        dispatcher.register(
+            literal<Sender>("op")
+                .permission("krypton.command.op", PermissionLevel.LEVEL_3)
+                .then(
+                    argument<Sender, EntityQuery>("targets", GameProfileArgument.gameProfile())
+                        .executes {
+                        val targets = it.gameProfileArgument("targets").getProfiles(it.source)
+                        val server = it.source.server as KryptonServer
+                        for (target in targets) {
+                            val ops = server.playerManager.ops
+                            if (!ops.contains(target)) {
+                                server.playerManager.addToOperators(target)
+                                it.source.sendMessage(
+                                    translatable(
+                                        "commands.op.success",
+                                        listOf(target.name.toComponent())
+                                    )
+                                )
+                            } else {
+                                throw ALREADY_OPPED_EXCEPTION.create()
+                            }
+                        }
+                        1
+                    })
+        )
+    }
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/PardonCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/PardonCommand.kt
@@ -1,0 +1,67 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
+import net.kyori.adventure.text.Component.translatable
+import org.kryptonmc.api.command.PermissionLevel
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.KryptonServer
+import org.kryptonmc.krypton.auth.GameProfile
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.arguments.GameProfileArgument
+import org.kryptonmc.krypton.command.arguments.entities.EntityQuery
+import org.kryptonmc.krypton.command.arguments.gameProfileArgument
+import org.kryptonmc.krypton.command.permission
+import org.kryptonmc.krypton.command.suggest
+import org.kryptonmc.krypton.util.toComponent
+
+object PardonCommand : InternalCommand {
+
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        dispatcher.register(
+            literal<Sender>("pardon")
+                .permission("krypton.command.pardon", PermissionLevel.LEVEL_3)
+                .then(
+                    argument<Sender, EntityQuery>("targets", GameProfileArgument.gameProfile())
+                        .suggests { context, builder ->
+                            builder.suggest((context.source.server as KryptonServer).playerManager.bannedPlayers.map { it.key.name })
+                        }
+                        .executes {
+                            unban(
+                                it.gameProfileArgument("targets").getProfiles(it.source),
+                                server = it.source.server as KryptonServer,
+                                sender = it.source
+                            )
+                            1
+                        })
+        )
+    }
+
+    private fun unban(targets: List<GameProfile>, sender: Sender, server: KryptonServer) {
+        for (target in targets) {
+            if (server.playerManager.bannedPlayers.contains(target)) {
+                server.playerManager.bannedPlayers -= target
+                sender.sendMessage(translatable("commands.pardon.success", listOf(target.name.toComponent())))
+            }
+        }
+    }
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/PardonIpCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/PardonIpCommand.kt
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.arguments.StringArgumentType.string
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
+import net.kyori.adventure.text.Component.translatable
+import org.kryptonmc.api.adventure.toMessage
+import org.kryptonmc.api.command.PermissionLevel
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.KryptonServer
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.permission
+import org.kryptonmc.krypton.command.suggest
+import org.kryptonmc.krypton.util.argument
+
+object PardonIpCommand : InternalCommand {
+
+    private val INVALID_IP_EXCEPTION = SimpleCommandExceptionType(translatable("commands.pardonip.invalid").toMessage())
+    private val ALREADY_UNBANNED_EXCEPTION =
+        SimpleCommandExceptionType(translatable("commands.pardonip.failed").toMessage())
+
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        dispatcher.register(
+            literal<Sender>("pardon-ip")
+                .permission("krypton.command.pardonip", PermissionLevel.LEVEL_3)
+                .then(
+                    argument<Sender, String>("target", string())
+                .suggests { context, builder ->
+                    builder.suggest((context.source.server as KryptonServer).playerManager.bannedIps.map { it.key })
+                }
+                .executes {
+                    unbanIp(it.source, it.argument("target"))
+                    1
+                })
+        )
+    }
+
+    fun unbanIp(sender: Sender, target: String) {
+        val server = sender.server as KryptonServer
+        if (target.matches(BanIpCommand.PATTERN)) {
+            if (server.playerManager.bannedIps.contains(target)) {
+                server.playerManager.bannedIps -= target
+            } else {
+                throw ALREADY_UNBANNED_EXCEPTION.create()
+            }
+        } else {
+            throw INVALID_IP_EXCEPTION.create()
+        }
+    }
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/RestartCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/RestartCommand.kt
@@ -18,15 +18,25 @@
  */
 package org.kryptonmc.krypton.command.commands
 
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import org.kryptonmc.api.command.PermissionLevel
 import org.kryptonmc.api.command.Sender
-import org.kryptonmc.api.command.SimpleCommand
 import org.kryptonmc.krypton.KryptonServer
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.permission
 import org.kryptonmc.krypton.locale.Messages
 
-internal class RestartCommand(private val server: KryptonServer) : SimpleCommand("restart", "krypton.command.restart") {
+class RestartCommand(private val server: KryptonServer) : InternalCommand {
 
-    override fun execute(sender: Sender, args: Array<String>) {
-        Messages.COMMANDS.RESTART.send(sender)
-        server.restart()
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        dispatcher.register(literal<Sender>("restart")
+            .permission("krypton.command.restart", PermissionLevel.LEVEL_4)
+            .executes {
+                Messages.COMMANDS.RESTART.send(it.source)
+                server.restart()
+                1
+            })
     }
+
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/SayCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/SayCommand.kt
@@ -1,0 +1,55 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.arguments.StringArgumentType.string
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.Component.translatable
+import org.kryptonmc.api.command.PermissionLevel
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.KryptonServer
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.permission
+import org.kryptonmc.krypton.util.argument
+import org.kryptonmc.krypton.util.toComponent
+
+object SayCommand : InternalCommand {
+
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        dispatcher.register(
+            literal<Sender>("say")
+                .permission("krypton.command.say", PermissionLevel.LEVEL_2)
+                .then(
+                    argument<Sender, String>("message", string())
+                        .executes {
+                            val server = it.source.server as KryptonServer
+                            server.broadcast(
+                                translatable(
+                                    "chat.type.announcement",
+                                    listOf(it.source.name.toComponent(), text(it.argument<String>("message")))
+                                )
+                            )
+                            1
+                        })
+        )
+    }
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/SeedCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/SeedCommand.kt
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.Component.translatable
+import net.kyori.adventure.text.format.TextColor
+import org.kryptonmc.api.command.PermissionLevel
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.permission
+import org.kryptonmc.krypton.entity.player.KryptonPlayer
+
+object SeedCommand : InternalCommand {
+
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        dispatcher.register(
+            literal<Sender>("seed")
+                .permission("krypton.command.seed", PermissionLevel.LEVEL_2)
+                .executes {
+                    val sender = it.source as? KryptonPlayer ?: return@executes 1
+                    val text = text("[").append(text(sender.world.seed, TextColor.color(5635925))).append(text("]"))
+                    sender.sendMessage(translatable("commands.seed.success", listOf(text)))
+                    1
+            })
+    }
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/StopCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/StopCommand.kt
@@ -18,15 +18,24 @@
  */
 package org.kryptonmc.krypton.command.commands
 
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import org.kryptonmc.api.command.PermissionLevel
 import org.kryptonmc.api.command.Sender
-import org.kryptonmc.api.command.SimpleCommand
 import org.kryptonmc.krypton.KryptonServer
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.permission
 import org.kryptonmc.krypton.locale.Messages
 
-internal class StopCommand(private val server: KryptonServer) : SimpleCommand("stop", "krypton.command.stop") {
+class StopCommand(private val server: KryptonServer) : InternalCommand {
 
-    override fun execute(sender: Sender, args: Array<String>) {
-        Messages.COMMANDS.STOP.send(sender)
-        server.stop()
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        dispatcher.register(literal<Sender>("stop")
+            .permission("krypton.command.stop", PermissionLevel.LEVEL_4)
+            .executes {
+                Messages.COMMANDS.STOP.send(it.source)
+                server.stop()
+                1
+            })
     }
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/TeleportCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/TeleportCommand.kt
@@ -21,23 +21,101 @@ package org.kryptonmc.krypton.command.commands
 import com.mojang.brigadier.CommandDispatcher
 import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
 import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
+import net.kyori.adventure.text.Component.translatable
+import org.kryptonmc.api.command.PermissionLevel
 import org.kryptonmc.api.command.Sender
 import org.kryptonmc.api.entity.player.Player
+import org.kryptonmc.api.world.Location
 import org.kryptonmc.krypton.command.InternalCommand
 import org.kryptonmc.krypton.command.arguments.VectorArgument
 import org.kryptonmc.krypton.command.arguments.coordinates.Coordinates
+import org.kryptonmc.krypton.command.arguments.entities.EntityArgument
+import org.kryptonmc.krypton.command.arguments.entities.EntityQuery
+import org.kryptonmc.krypton.command.arguments.entities.entityArgument
+import org.kryptonmc.krypton.command.permission
+import org.kryptonmc.krypton.entity.player.KryptonPlayer
+import org.kryptonmc.krypton.util.argument
+import org.kryptonmc.krypton.util.toComponent
 
 internal object TeleportCommand : InternalCommand {
 
     override fun register(dispatcher: CommandDispatcher<Sender>) {
-        val node = dispatcher.register(literal<Sender>("teleport")
-            .then(argument<Sender, Coordinates>("location", VectorArgument(true))
-                .executes { teleport(it.source, it.getArgument("location", Coordinates::class.java)); 1 }))
-        dispatcher.register(literal<Sender>("tp").redirect(node))
+        val node = dispatcher.register(
+            literal<Sender>("teleport")
+                .permission("krypton.command.teleport", PermissionLevel.LEVEL_2)
+                .then(argument<Sender, Coordinates>("location", VectorArgument(true))
+                    .executes {
+                        teleport(it.source, it.getArgument("location", Coordinates::class.java)); 1
+                    })
+                .then(argument<Sender, EntityQuery>("players", EntityArgument.players())
+                    .executes {
+                        val sender = it.source as? KryptonPlayer ?: return@executes 1
+                        val players = it.entityArgument("players").getPlayers(sender)
+                        if (players.size == 1) {
+                            val player = players[0]
+                            teleport(sender, player.location)
+                            sender.sendMessage(
+                                translatable(
+                                    "commands.teleport.success.entity.single",
+                                    listOf(sender.name.toComponent(), player.name.toComponent())
+                                )
+                            )
+                        }
+                        1
+                    }
+                    .then(argument<Sender, EntityQuery>("target", EntityArgument.player())
+                        .executes {
+                            val sender = it.source as? KryptonPlayer ?: return@executes 1
+                            val players = it.entityArgument("players").getPlayers(sender)
+                            val target = it.entityArgument("target").getPlayers(sender)[0]
+                            for (player in players) {
+                                teleport(player, target.location)
+                            }
+                            sender.sendMessage(
+                                translatable(
+                                    "commands.teleport.success.entity.multiple",
+                                    listOf(players.size.toString().toComponent(), target.name.toComponent())
+                                )
+                            )
+                            1
+                        })
+                    .then(argument<Sender, Coordinates>("location", VectorArgument(true))
+                        .executes {
+                            val sender = it.source as? KryptonPlayer ?: return@executes 1
+                            val players = it.entityArgument("players").getPlayers(sender)
+                            val location = it.argument<Coordinates>("location")
+                            for (player in players) {
+                                teleport(player, location)
+                            }
+                            sender.sendMessage(
+                                translatable(
+                                    "commands.teleport.success.location.multiple",
+                                    listOf(
+                                        players.size.toString().toComponent(),
+                                        location.position(sender).blockX.toString().toComponent(),
+                                        location.position(sender).blockY.toString().toComponent(),
+                                        location.position(sender).blockZ.toString().toComponent()
+                                    )
+                                )
+                            )
+                            1
+                        })
+                )
+        )
+        dispatcher.register(
+            literal<Sender>("tp")
+                .permission("krypton.command.teleport", PermissionLevel.LEVEL_2)
+                .redirect(node)
+        )
     }
 
-    private fun teleport(sender: Sender, location: Coordinates) {
-        if (sender !is Player) return
-        sender.teleport(location.position(sender))
+    private fun teleport(player: Sender, location: Coordinates) {
+        if (player !is Player) return
+        player.teleport(location.position(player))
+    }
+
+    private fun teleport(player: Sender, location: Location) {
+        if (player !is Player) return
+        player.teleport(location)
     }
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/TitleCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/TitleCommand.kt
@@ -1,0 +1,205 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.arguments.IntegerArgumentType.integer
+import com.mojang.brigadier.arguments.StringArgumentType.string
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.Component.translatable
+import org.kryptonmc.api.command.PermissionLevel
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.arguments.entities.EntityArgument.Companion.players
+import org.kryptonmc.krypton.command.arguments.entities.EntityQuery
+import org.kryptonmc.krypton.command.arguments.entities.entityArgument
+import org.kryptonmc.krypton.command.permission
+import org.kryptonmc.krypton.entity.player.KryptonPlayer
+import org.kryptonmc.krypton.util.argument
+import java.time.Duration
+
+object TitleCommand : InternalCommand {
+
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        dispatcher.register(
+            literal<Sender>("title")
+                .permission("krypton.command.title", PermissionLevel.LEVEL_2)
+                .then(
+                    argument<Sender, EntityQuery>("targets", players())
+                        .then(
+                            literal<Sender>("actionbar")
+                                .then(
+                                    argument<Sender, String>("message", string())
+                                        .executes {
+                                        val sender = it.source as? KryptonPlayer ?: return@executes 1
+                                        val targets = it.entityArgument("targets").getPlayers(sender)
+                                        val message = it.argument<String>("message")
+                                        for (target in targets) {
+                                            target.sendActionBar(text(message))
+                                        }
+                                        val feedback = if (targets.size == 1) {
+                                            translatable(
+                                                "commands.title.show.actionbar.single",
+                                                listOf(text(sender.name))
+                                            )
+                                        } else {
+                                            translatable(
+                                                "commands.title.show.actionbar.multiple",
+                                                listOf(text(targets.size))
+                                            )
+                                        }
+                                        sender.sendMessage(feedback)
+                                        1
+                                    })
+                        )
+                        .then(
+                            literal<Sender>("title")
+                                .then(argument<Sender, String>("message", string())
+                                    .executes {
+                                        val sender = it.source as? KryptonPlayer ?: return@executes 1
+                                        val targets = it.entityArgument("targets").getPlayers(sender)
+                                        val message = it.argument<String>("message")
+                                        for (target in targets) {
+                                            target.sendTitle(text(message))
+                                        }
+                                        val feedback = if (targets.size == 1) {
+                                            translatable(
+                                                "commands.title.show.title.single",
+                                                listOf(text(sender.name))
+                                            )
+                                        } else {
+                                            translatable(
+                                                "commands.title.show.title.multiple",
+                                                listOf(text(targets.size))
+                                            )
+                                        }
+                                        sender.sendMessage(feedback)
+                                        1
+                                    })
+                        ).then(
+                            literal<Sender>("subtitle")
+                                .then(argument<Sender, String>("message", string())
+                                    .executes {
+                                        val sender = it.source as? KryptonPlayer ?: return@executes 1
+                                        val targets = it.entityArgument("targets").getPlayers(sender)
+                                        val message = it.argument<String>("message")
+                                        for (target in targets) {
+                                            target.sendSubtitle(text(message))
+                                        }
+                                        val feedback = if (targets.size == 1) {
+                                            translatable(
+                                                "commands.title.show.subtitle.single",
+                                                listOf(text(sender.name))
+                                            )
+                                        } else {
+                                            translatable(
+                                                "commands.title.show.subtitle.multiple",
+                                                listOf(text(targets.size))
+                                            )
+                                        }
+                                        sender.sendMessage(feedback)
+                                        1
+                                    })
+                        ).then(
+                            literal<Sender>("clear")
+                                .executes {
+                                    val sender = it.source as? KryptonPlayer ?: return@executes 1
+                                    val targets = it.entityArgument("targets").getPlayers(sender)
+                                    for (target in targets) {
+                                        target.clearTitle()
+                                    }
+                                    val feedback = if (targets.size == 1) {
+                                        translatable(
+                                            "commands.title.cleared.single",
+                                            listOf(text(sender.name))
+                                        )
+                                    } else {
+                                        translatable(
+                                            "commands.title.cleared.multiple",
+                                            listOf(text(targets.size))
+                                        )
+                                    }
+                                    sender.sendMessage(feedback)
+                                    1
+                                }
+                        ).then(
+                            literal<Sender>("reset")
+                                .executes {
+                                    val sender = it.source as? KryptonPlayer ?: return@executes 1
+                                    val targets = it.entityArgument("targets").getPlayers(sender)
+                                    for (target in targets) {
+                                        target.resetTitle()
+                                    }
+                                    val feedback = if (targets.size == 1) {
+                                        translatable(
+                                            "commands.title.reset.single",
+                                            listOf(text(sender.name))
+                                        )
+                                    } else {
+                                        translatable(
+                                            "commands.title.reset.multiple",
+                                            listOf(text(targets.size))
+                                        )
+                                    }
+                                    sender.sendMessage(feedback)
+                                    1
+                                })
+                        .then(
+                            literal<Sender>("times")
+                                .then(
+                                    argument<Sender, Int>("fadeIn", integer())
+                                        .then(
+                                            argument<Sender, Int>("stay", integer())
+                                                .then(argument<Sender, Int>("fadeOut", integer())
+                                                    .executes {
+                                                        val sender = it.source as? KryptonPlayer ?: return@executes 1
+                                                        val targets = it.entityArgument("targets").getPlayers(sender)
+                                                        val fadeIn = it.argument<Int>("fadeIn")
+                                                        val stay = it.argument<Int>("stay")
+                                                        val fadeOut = it.argument<Int>("fadeOut")
+                                                        for (target in targets) {
+                                                            target.sendTitleTimes(
+                                                                Duration.ofSeconds(fadeIn.toLong()),
+                                                                Duration.ofSeconds(stay.toLong()),
+                                                                Duration.ofSeconds(fadeOut.toLong())
+                                                            )
+                                                        }
+                                                        val feedback = if (targets.size == 1) {
+                                                            translatable(
+                                                                "commands.title.times.single",
+                                                                listOf(text(sender.name))
+                                                            )
+                                                        } else {
+                                                            translatable(
+                                                                "commands.title.times.multiple",
+                                                                listOf(text(targets.size))
+                                                            )
+                                                        }
+                                                        sender.sendMessage(feedback)
+                                                        1
+                                                    })
+                                        )
+                                )
+                        )
+                )
+        )
+    }
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/VersionCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/VersionCommand.kt
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.event.ClickEvent
+import net.kyori.adventure.text.format.TextColor
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.entity.player.KryptonPlayer
+
+object VersionCommand : InternalCommand {
+
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        val node = dispatcher.register(
+            literal<Sender>("version")
+                .executes {
+                    val sender = it.source as? KryptonPlayer ?: return@executes 1
+                    val version = sender.server.info.version
+                    val minecraftVersion = sender.server.info.minecraftVersion
+                    val pluginsLoaded = sender.server.pluginManager.plugins.size
+                    val text = text("Krypton\n")
+                        .clickEvent(ClickEvent.openUrl("https://github.com/KryptonMC/Krypton"))
+                    .color(TextColor.color(17, 255, 0))
+                    .append(column("Version: ", version))
+                    .append(column("Minecraft Version: ", minecraftVersion))
+                    .append(column("Plugins Loaded: ", pluginsLoaded.toString()))
+                sender.sendMessage(text)
+                1
+            })
+        dispatcher.register(
+            literal<Sender>("about")
+                .redirect(node)
+        )
+    }
+
+    private fun column(option: String, value: String): TextComponent {
+        return text(option).color(TextColor.color(255, 251, 33))
+            .append(text(value + "\n").color(TextColor.color(0, 196, 244)))
+    }
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/WhitelistCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/WhitelistCommand.kt
@@ -1,0 +1,209 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.arguments.StringArgumentType.string
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
+import net.kyori.adventure.text.Component.translatable
+import org.kryptonmc.api.command.PermissionLevel
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.KryptonServer
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.arguments.GameProfileArgument
+import org.kryptonmc.krypton.command.arguments.entities.EntityQuery
+import org.kryptonmc.krypton.command.arguments.gameProfileArgument
+import org.kryptonmc.krypton.command.permission
+import org.kryptonmc.krypton.command.suggest
+import org.kryptonmc.krypton.server.whitelist.WhitelistEntry
+import org.kryptonmc.krypton.server.whitelist.WhitelistIpEntry
+import org.kryptonmc.krypton.util.argument
+import org.kryptonmc.krypton.util.stringify
+import org.kryptonmc.krypton.util.toComponent
+
+object WhitelistCommand : InternalCommand {
+
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        dispatcher.register(
+            literal<Sender>("whitelist")
+                .permission("krypton.command.whitelist", PermissionLevel.LEVEL_3)
+                .then(
+                    literal<Sender>("on")
+                        .executes {
+                            val sender = it.source
+                            val server = sender.server as KryptonServer
+                            if (!server.playerManager.whitelistEnabled) {
+                            server.playerManager.whitelistEnabled = true
+                            sender.sendMessage(translatable("commands.whitelist.enabled"))
+                        } else {
+                            sender.sendMessage(translatable("commands.whitelist.alreadyOn"))
+                        }
+                        1
+                    })
+                .then(literal<Sender>("off")
+                    .executes {
+                        val sender = it.source
+                        val server = sender.server as KryptonServer
+                        if (server.playerManager.whitelistEnabled) {
+                            server.playerManager.whitelistEnabled = false
+                            sender.sendMessage(translatable("commands.whitelist.disabled"))
+                        } else {
+                            sender.sendMessage(translatable("commands.whitelist.alreadyOff"))
+                        }
+                        1
+                    })
+                .then(literal<Sender>("list")
+                    .executes {
+                        val sender = it.source
+                        val server = it.source.server as KryptonServer
+                        val whitelist = server.playerManager.whitelist
+                        if (whitelist.isEmpty()) {
+                            sender.sendMessage(translatable("commands.whitelist.none"))
+                        } else {
+                            sender.sendMessage(
+                                translatable(
+                                    "commands.whitelist.list",
+                                    listOf(
+                                        whitelist.size.toString().toComponent(),
+                                        whitelist.joinToString().toComponent()
+                                    )
+                                )
+                            )
+                        }
+                        1
+                    })
+                .then(
+                    literal<Sender>("add")
+                        .then(argument<Sender, EntityQuery>("targets", GameProfileArgument.gameProfile())
+                            .executes {
+                                val sender = it.source
+                                val server = sender.server as KryptonServer
+                                val targets = it.gameProfileArgument("targets").getProfiles(sender)
+                                for (target in targets) {
+                                    val whitelist = server.playerManager.whitelist
+                                    if (!whitelist.contains(target)) {
+                                        whitelist += WhitelistEntry(target)
+                                        sender.sendMessage(
+                                            translatable(
+                                                "commands.whitelist.add.success",
+                                                listOf(target.name.toComponent())
+                                            )
+                                        )
+                                    } else {
+                                        sender.sendMessage(translatable("commands.whitelist.add.failed"))
+                                    }
+                                }
+                                1
+                            })
+                )
+                .then(
+                    literal<Sender>("remove")
+                        .then(argument<Sender, EntityQuery>("targets", GameProfileArgument.gameProfile())
+                            .executes {
+                                val sender = it.source
+                                val server = sender.server as KryptonServer
+                                val targets = it.gameProfileArgument("targets").getProfiles(sender)
+                                for (target in targets) {
+                                    val whitelist = server.playerManager.whitelist
+                                    if (whitelist.contains(target)) {
+                                        whitelist -= target
+                                        sender.sendMessage(
+                                            translatable(
+                                                "commands.whitelist.remove.success",
+                                                listOf(target.name.toComponent())
+                                            )
+                                        )
+                                    } else {
+                                        sender.sendMessage(translatable("commands.whitelist.remove.failed"))
+                                    }
+                                }
+                                1
+                            })
+                )
+                .then(
+                    literal<Sender>("add-ip")
+                        .then(argument<Sender, String>("target", string())
+                            .executes {
+                                val sender = it.source
+                                val server = sender.server as KryptonServer
+                                val target = it.argument<String>("target")
+                                whitelistIp(server, target, sender)
+                                1
+                            })
+                )
+                .then(
+                    literal<Sender>("remove-ip")
+                        .then(argument<Sender, String>("ip", string())
+                            .suggests { context, builder -> builder.suggest((context.source.server as KryptonServer).playerManager.whitlistedIps.map { it.key }) }
+                            .executes {
+                                val sender = it.source
+                                val server = sender.server as KryptonServer
+                                val ip = it.argument<String>("ip")
+                                if (server.playerManager.whitlistedIps.contains(ip)) {
+                                    server.playerManager.whitlistedIps -= ip
+                                    sender.sendMessage(
+                                        translatable(
+                                            "commands.whitelist.remove.success",
+                                            listOf(ip.toComponent())
+                                        )
+                                    )
+                                } else {
+                                    sender.sendMessage(translatable("commands.whitelist.remove.failed"))
+                                }
+                                1
+                            })
+                )
+        )
+    }
+
+    private fun whitelistIp(server: KryptonServer, target: String, sender: Sender) {
+        if (target.matches(BanIpCommand.PATTERN)) {
+            if (server.playerManager.whitlistedIps.contains(target)) {
+                sender.sendMessage(translatable("commands.whitelist.add.failed"))
+            } else {
+                val entry = WhitelistIpEntry(target)
+                server.playerManager.whitlistedIps += entry
+                sender.sendMessage(
+                    translatable(
+                        "commands.whitelist.add.success",
+                        listOf(target.toComponent())
+                    )
+                )
+            }
+        } else if (server.player(target) != null) {
+            val adress = server.player(target)!!.address.stringify()
+            if (server.playerManager.whitlistedIps.contains(adress)) {
+                sender.sendMessage(translatable("commands.whitelist.add.failed"))
+            } else {
+                val entry = WhitelistIpEntry(adress)
+                server.playerManager.whitlistedIps += entry
+                sender.sendMessage(
+                    translatable(
+                        "commands.whitelist.add.success",
+                        listOf(target.toComponent())
+                    )
+                )
+            }
+        } else {
+            sender.sendMessage(translatable("commands.banip.invalid"))
+        }
+    }
+
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/config/KryptonConfig.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/config/KryptonConfig.kt
@@ -54,7 +54,7 @@ data class KryptonConfig(
     @Comment("Proxy IP forwarding settings.")
     val proxy: ProxyCategory = ProxyCategory(),
     @Comment("Other settings that don't quite fit in anywhere else.")
-    val other: OtherCategory = OtherCategory()
+    val other: OtherCategory = OtherCategory(),
 ) {
 
     companion object {

--- a/server/src/main/kotlin/org/kryptonmc/krypton/config/category/ServerCategory.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/config/category/ServerCategory.kt
@@ -33,5 +33,11 @@ data class ServerCategory(
     val onlineMode: Boolean = true,
     @Setting("compression-threshold")
     @Comment("The threshold at which packets larger will be compressed. Set to -1 to disable.")
-    val compressionThreshold: Int = 256
+    val compressionThreshold: Int = 256,
+    @Setting("whitelist-enabled")
+    @Comment("Whether only specific users can join the server or not")
+    var whitelistEnabled: Boolean = false,
+    @Setting("op-permission-level")
+    @Comment("The permission level operators will get")
+    val opPermissionLevel: Int = 4
 )

--- a/server/src/main/kotlin/org/kryptonmc/krypton/console/KryptonConsoleSender.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/console/KryptonConsoleSender.kt
@@ -23,6 +23,8 @@ import net.kyori.adventure.identity.Identity
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.renderer.TranslatableComponentRenderer
 import org.kryptonmc.api.command.ConsoleSender
+import org.kryptonmc.api.command.PermissionLevel
+import org.kryptonmc.krypton.KryptonServer
 import org.kryptonmc.krypton.adventure.toSectionText
 import org.kryptonmc.krypton.locale.TranslationBootstrap
 import org.kryptonmc.krypton.util.logger
@@ -31,10 +33,11 @@ import java.util.Locale
 /**
  * Our implementation of the API's [ConsoleSender].
  */
-object KryptonConsoleSender : ConsoleSender {
+class KryptonConsoleSender(override val server: KryptonServer) : ConsoleSender {
 
     private val LOGGER = logger("CONSOLE")
     private val RENDERER = TranslatableComponentRenderer.usingTranslationSource(TranslationBootstrap.REGISTRY)
+    override val permissionLevel = PermissionLevel.LEVEL_4
 
     override fun sendMessage(source: Identity, message: Component, type: MessageType) {
         LOGGER.info(RENDERER.render(message, Locale.ENGLISH).toSectionText())

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/player/KryptonPlayer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/player/KryptonPlayer.kt
@@ -32,6 +32,7 @@ import net.kyori.adventure.text.event.HoverEvent.ShowEntity
 import net.kyori.adventure.text.event.HoverEvent.showEntity
 import net.kyori.adventure.title.Title
 import org.kryptonmc.api.block.Block
+import org.kryptonmc.api.command.PermissionLevel
 import org.kryptonmc.api.effect.particle.ColorParticleData
 import org.kryptonmc.api.effect.particle.DirectionalParticleData
 import org.kryptonmc.api.effect.particle.NoteParticleData
@@ -59,6 +60,8 @@ import org.kryptonmc.krypton.entity.attribute.Attributes
 import org.kryptonmc.krypton.entity.metadata.MetadataKeys
 import org.kryptonmc.krypton.inventory.KryptonPlayerInventory
 import org.kryptonmc.krypton.item.handler
+import org.kryptonmc.krypton.item.toItemStack
+import org.kryptonmc.krypton.network.Session
 import org.kryptonmc.krypton.packet.out.play.GameState
 import org.kryptonmc.krypton.packet.out.play.PacketOutAbilities
 import org.kryptonmc.krypton.packet.out.play.PacketOutActionBar
@@ -67,12 +70,13 @@ import org.kryptonmc.krypton.packet.out.play.PacketOutChangeGameState
 import org.kryptonmc.krypton.packet.out.play.PacketOutChat
 import org.kryptonmc.krypton.packet.out.play.PacketOutChunkData
 import org.kryptonmc.krypton.packet.out.play.PacketOutClearTitles
-import org.kryptonmc.krypton.packet.out.play.PacketOutMetadata
 import org.kryptonmc.krypton.packet.out.play.PacketOutEntityPosition
 import org.kryptonmc.krypton.packet.out.play.PacketOutEntityTeleport
+import org.kryptonmc.krypton.packet.out.play.PacketOutMetadata
 import org.kryptonmc.krypton.packet.out.play.PacketOutNamedSoundEffect
 import org.kryptonmc.krypton.packet.out.play.PacketOutOpenBook
 import org.kryptonmc.krypton.packet.out.play.PacketOutParticle
+import org.kryptonmc.krypton.packet.out.play.PacketOutPlayerInfo
 import org.kryptonmc.krypton.packet.out.play.PacketOutPlayerListHeaderFooter
 import org.kryptonmc.krypton.packet.out.play.PacketOutPluginMessage
 import org.kryptonmc.krypton.packet.out.play.PacketOutSetSlot
@@ -84,22 +88,19 @@ import org.kryptonmc.krypton.packet.out.play.PacketOutTitleTimes
 import org.kryptonmc.krypton.packet.out.play.PacketOutUnloadChunk
 import org.kryptonmc.krypton.packet.out.play.PacketOutUpdateLight
 import org.kryptonmc.krypton.packet.out.play.PacketOutUpdateViewPosition
-import org.kryptonmc.krypton.network.Session
 import org.kryptonmc.krypton.util.calculatePositionChange
 import org.kryptonmc.krypton.util.chunkInSpiral
 import org.kryptonmc.krypton.util.logger
 import org.kryptonmc.krypton.util.nbt.NBTOps
 import org.kryptonmc.krypton.util.toArea
-import org.kryptonmc.krypton.item.toItemStack
-import org.kryptonmc.krypton.packet.out.play.PacketOutPlayerInfo
 import org.kryptonmc.krypton.world.KryptonWorld
 import org.kryptonmc.krypton.world.bossbar.BossBarManager
 import org.kryptonmc.krypton.world.chunk.ChunkPosition
 import org.kryptonmc.nbt.CompoundTag
 import org.kryptonmc.nbt.IntTag
-import org.kryptonmc.nbt.compound
 import org.spongepowered.math.vector.Vector3i
 import java.net.InetSocketAddress
+import java.time.Duration
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.UnaryOperator
@@ -124,6 +125,9 @@ class KryptonPlayer(
     override var viewDistance = 10
     override var time = 0L
 
+    override val permissionLevel: PermissionLevel
+        get() = server.getPermissionLevel(profile)
+
     private var camera: KryptonEntity = this
         set(value) {
             val old = field
@@ -142,6 +146,7 @@ class KryptonPlayer(
             field = value
             updateAbilities()
             onAbilitiesUpdate()
+            server.playerManager.sendToAll(PacketOutPlayerInfo(PacketOutPlayerInfo.PlayerAction.UPDATE_GAMEMODE, this))
             session.sendPacket(PacketOutChangeGameState(GameState.CHANGE_GAMEMODE, value.ordinal.toFloat()))
             if (value != Gamemode.SPECTATOR) camera = this
         }
@@ -287,8 +292,18 @@ class KryptonPlayer(
 
     override fun showTitle(title: Title) {
         session.sendPacket(PacketOutTitle(title.title()))
-        session.sendPacket(PacketOutSubTitle(title.subtitle()))
-        title.times()?.let { session.sendPacket(PacketOutTitleTimes(it)) }
+    }
+
+    internal fun sendTitle(title: Component) {
+        session.sendPacket(PacketOutTitle(title))
+    }
+
+    internal fun sendSubtitle(subtitle: Component) {
+        session.sendPacket(PacketOutSubTitle(subtitle))
+    }
+
+    internal fun sendTitleTimes(fadeIn: Duration, stay: Duration, fadeOut: Duration) {
+        session.sendPacket(PacketOutTitleTimes(Title.Times.of(fadeIn, stay, fadeOut)))
     }
 
     override fun clearTitle() {
@@ -390,12 +405,17 @@ class KryptonPlayer(
         }
     }
 
-    override fun hasCorrectTool(block: Block): Boolean = !block.requiresCorrectTool || inventory.mainHand.type.handler.isCorrectTool(block)
+    override fun hasCorrectTool(block: Block): Boolean =
+        !block.requiresCorrectTool || inventory.mainHand.type.handler.isCorrectTool(block)
 
     override fun getDestroySpeed(block: Block): Float {
         var speed = inventory.mainHand.getDestroySpeed(block)
         if (!isOnGround) speed /= 5F
         return speed
+    }
+
+    override fun disconnect(text: Component) {
+        session.disconnect(text)
     }
 
     private fun onAbilitiesUpdate() {

--- a/server/src/main/kotlin/org/kryptonmc/krypton/network/handlers/LoginHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/network/handlers/LoginHandler.kt
@@ -22,28 +22,18 @@ import com.velocitypowered.natives.util.Natives
 import io.netty.buffer.Unpooled
 import kotlinx.coroutines.launch
 import net.kyori.adventure.text.Component
-import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.Component.translatable
-import net.kyori.adventure.text.format.NamedTextColor
-import org.kryptonmc.krypton.KryptonServer
 import org.kryptonmc.api.event.login.LoginEvent
 import org.kryptonmc.krypton.IOScope
+import org.kryptonmc.krypton.KryptonServer
 import org.kryptonmc.krypton.auth.GameProfile
 import org.kryptonmc.krypton.auth.exceptions.AuthenticationException
 import org.kryptonmc.krypton.auth.requests.SessionService
 import org.kryptonmc.krypton.config.category.ForwardingMode
 import org.kryptonmc.krypton.entity.player.KryptonPlayer
 import org.kryptonmc.krypton.locale.Messages
-import org.kryptonmc.krypton.packet.Packet
-import org.kryptonmc.krypton.packet.`in`.login.PacketInEncryptionResponse
-import org.kryptonmc.krypton.packet.`in`.login.PacketInLoginStart
-import org.kryptonmc.krypton.packet.`in`.login.PacketInPluginResponse
-import org.kryptonmc.krypton.packet.out.login.PacketOutEncryptionRequest
-import org.kryptonmc.krypton.packet.out.login.PacketOutLoginSuccess
-import org.kryptonmc.krypton.packet.out.login.PacketOutPluginRequest
-import org.kryptonmc.krypton.packet.out.login.PacketOutSetCompression
-import org.kryptonmc.krypton.network.Session
 import org.kryptonmc.krypton.network.PacketState
+import org.kryptonmc.krypton.network.Session
 import org.kryptonmc.krypton.network.netty.PacketCompressor
 import org.kryptonmc.krypton.network.netty.PacketDecoder
 import org.kryptonmc.krypton.network.netty.PacketDecompressor
@@ -52,12 +42,23 @@ import org.kryptonmc.krypton.network.netty.PacketEncoder
 import org.kryptonmc.krypton.network.netty.PacketEncrypter
 import org.kryptonmc.krypton.network.netty.SizeDecoder
 import org.kryptonmc.krypton.network.netty.SizeEncoder
+import org.kryptonmc.krypton.packet.Packet
+import org.kryptonmc.krypton.packet.`in`.login.PacketInEncryptionResponse
+import org.kryptonmc.krypton.packet.`in`.login.PacketInLoginStart
+import org.kryptonmc.krypton.packet.`in`.login.PacketInPluginResponse
+import org.kryptonmc.krypton.packet.out.login.PacketOutEncryptionRequest
+import org.kryptonmc.krypton.packet.out.login.PacketOutLoginSuccess
+import org.kryptonmc.krypton.packet.out.login.PacketOutPluginRequest
+import org.kryptonmc.krypton.packet.out.login.PacketOutSetCompression
+import org.kryptonmc.krypton.server.ban.BanEntry
 import org.kryptonmc.krypton.util.BungeeCordHandshakeData
 import org.kryptonmc.krypton.util.encryption.Encryption
 import org.kryptonmc.krypton.util.logger
 import org.kryptonmc.krypton.util.readVelocityData
+import org.kryptonmc.krypton.util.toComponent
 import org.kryptonmc.krypton.util.verifyIntegrity
 import java.net.InetSocketAddress
+import java.net.SocketAddress
 import java.util.UUID
 import javax.crypto.SecretKey
 import javax.crypto.spec.SecretKeySpec
@@ -98,7 +99,8 @@ class LoginHandler(
 
     private fun handleLoginStart(packet: PacketInLoginStart) {
         val rawAddress = session.channel.remoteAddress() as InetSocketAddress
-        val address = if (bungeecordData != null) InetSocketAddress(bungeecordData.forwardedIp, rawAddress.port) else rawAddress
+        val address =
+            if (bungeecordData != null) InetSocketAddress(bungeecordData.forwardedIp, rawAddress.port) else rawAddress
 
         name = packet.name
         if (!server.isOnline) {
@@ -108,9 +110,10 @@ class LoginHandler(
             }
 
             // Note: Per the protocol, offline players use UUID v3, rather than UUID v4.
-            val uuid = bungeecordData?.uuid ?: UUID.nameUUIDFromBytes("OfflinePlayer:${packet.name}".encodeToByteArray())
+            val uuid =
+                bungeecordData?.uuid ?: UUID.nameUUIDFromBytes("OfflinePlayer:${packet.name}".encodeToByteArray())
             val profile = GameProfile(uuid, packet.name, bungeecordData?.properties ?: emptyList())
-
+            if (!canJoin(profile, address)) return
             val player = KryptonPlayer(session, profile, server.worldManager.default, address)
             if (!callLoginEvent(profile)) return
             finishLogin(player)
@@ -127,8 +130,14 @@ class LoginHandler(
         enableEncryption(secretKey)
 
         IOScope.launch {
+            val rawAddress = session.channel.remoteAddress() as InetSocketAddress
+            val address = if (bungeecordData != null) InetSocketAddress(
+                bungeecordData.forwardedIp,
+                rawAddress.port
+            ) else rawAddress
             val profile = try {
                 val value = SessionService.authenticateUser(name, sharedSecret, server.config.server.ip)
+                if (!canJoin(value, address)) return@launch
                 if (!callLoginEvent(value)) return@launch
                 value
             } catch (exception: AuthenticationException) {
@@ -137,8 +146,6 @@ class LoginHandler(
             }
             enableCompression()
 
-            val rawAddress = session.channel.remoteAddress() as InetSocketAddress
-            val address = if (bungeecordData != null) InetSocketAddress(bungeecordData.forwardedIp, rawAddress.port) else rawAddress
             val player = KryptonPlayer(session, profile, server.worldManager.default, address)
             finishLogin(player)
         }
@@ -146,7 +153,7 @@ class LoginHandler(
 
     private fun handlePluginResponse(packet: PacketInPluginResponse) {
         if (!packet.isSuccessful) // not successful, we don't care for now
-        if (packet.messageId != velocityMessageId || server.config.proxy.mode != ForwardingMode.MODERN) return // not Velocity, ignore (for now)
+            if (packet.messageId != velocityMessageId || server.config.proxy.mode != ForwardingMode.MODERN) return // not Velocity, ignore (for now)
         if (packet.data.isEmpty()) error("Velocity sent no data in its login plugin response!")
         val secret = server.config.proxy.secret.encodeToByteArray()
 
@@ -162,7 +169,12 @@ class LoginHandler(
 
         LOGGER.debug("Detected Velocity login for ${data.uuid}")
         val profile = GameProfile(data.uuid, data.username, data.properties)
-        val player = KryptonPlayer(session, profile, server.worldManager.default, InetSocketAddress(data.remoteAddress, address.port))
+        val player = KryptonPlayer(
+            session,
+            profile,
+            server.worldManager.default,
+            InetSocketAddress(data.remoteAddress, address.port)
+        )
         finishLogin(player)
     }
 
@@ -176,7 +188,12 @@ class LoginHandler(
     private fun verifyToken(expected: ByteArray, actual: ByteArray): Boolean {
         val decryptedActual = Encryption.decrypt(actual)
         require(decryptedActual.contentEquals(expected)) {
-            Messages.NETWORK.LOGIN.FAIL_VERIFY_ERROR.error(LOGGER, name, expected.contentToString(), decryptedActual.contentToString())
+            Messages.NETWORK.LOGIN.FAIL_VERIFY_ERROR.error(
+                LOGGER,
+                name,
+                expected.contentToString(),
+                decryptedActual.contentToString()
+            )
             session.disconnect(translatable("disconnect.loginFailedInfo", listOf(Messages.NETWORK.LOGIN.FAIL_VERIFY())))
             return false
         }
@@ -224,9 +241,41 @@ class LoginHandler(
         val event = LoginEvent(profile.name, profile.uuid, session.channel.remoteAddress() as InetSocketAddress)
         val result = server.eventManager.fireSync(event).result
         if (!result.isAllowed) {
-            val reason = if (result.reason !== Component.empty()) result.reason else translatable("multiplayer.disconnect.kicked")
+            val reason =
+                if (result.reason !== Component.empty()) result.reason else translatable("multiplayer.disconnect.kicked")
             session.disconnect(reason)
             return false
+        }
+        return true
+    }
+
+    private fun canJoin(profile: GameProfile, address: SocketAddress): Boolean {
+        if (playerManager.bannedPlayers.contains(profile)) {
+            val entry = playerManager.bannedPlayers[profile]!!
+            val text = translatable("multiplayer.disconnect.banned.reason", listOf(entry.reason.toComponent()))
+            if (entry.expiryDate != null) text.append(
+                translatable(
+                    "multiplayer.disconnect.banned.expiration", listOf(
+                        BanEntry.DATE_FORMAT.format(entry.expiryDate).toComponent()
+                    )
+                )
+            )
+            session.disconnect(text)
+            return false
+        } else if (playerManager.whitelistEnabled && !playerManager.whitelist.contains(profile) && !playerManager.whitlistedIps.isWhitelisted(
+                address
+            )
+        ) {
+            session.disconnect(translatable("multiplayer.disconnect.not_whitelisted"))
+            return false
+        } else if (playerManager.bannedIps.isBanned(address)) {
+            val entry = playerManager.bannedIps[address]!!
+            session.disconnect(
+                translatable(
+                    "multiplayer.disconnect.banned_ip.reason",
+                    listOf(entry.reason.toComponent())
+                )
+            )
         }
         return true
     }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/network/handlers/LoginHandler.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/network/handlers/LoginHandler.kt
@@ -261,21 +261,28 @@ class LoginHandler(
                 )
             )
             session.disconnect(text)
+            LOGGER.info("${profile.name} disconnected. Reason: Banned")
             return false
-        } else if (playerManager.whitelistEnabled && !playerManager.whitelist.contains(profile) && !playerManager.whitlistedIps.isWhitelisted(
-                address
-            )
+        } else if (playerManager.whitelistEnabled && !playerManager.whitelist.contains(profile) && !playerManager.whitlistedIps.isWhitelisted(address)
         ) {
             session.disconnect(translatable("multiplayer.disconnect.not_whitelisted"))
+            LOGGER.info("${profile.name} disconnected. Reason: Not whitelisted")
             return false
         } else if (playerManager.bannedIps.isBanned(address)) {
             val entry = playerManager.bannedIps[address]!!
-            session.disconnect(
+            val text = translatable(
+                "multiplayer.disconnect.banned_ip.reason",
+                listOf(entry.reason.toComponent())
+            )
+            if (entry.expiryDate != null) text.append(
                 translatable(
-                    "multiplayer.disconnect.banned_ip.reason",
-                    listOf(entry.reason.toComponent())
+                    "multiplayer.disconnect.banned.expiration", listOf(
+                        BanEntry.DATE_FORMAT.format(entry.expiryDate).toComponent()
+                    )
                 )
             )
+            session.disconnect(text)
+            LOGGER.info("${profile.name} disconnected. Reason: IP Banned")
         }
         return true
     }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/PlayerManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/PlayerManager.kt
@@ -21,29 +21,30 @@ package org.kryptonmc.krypton.server
 import net.kyori.adventure.audience.ForwardingAudience
 import net.kyori.adventure.key.Key
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.Component.text
 import org.kryptonmc.api.event.login.JoinEvent
 import org.kryptonmc.api.event.play.QuitEvent
 import org.kryptonmc.api.world.rule.GameRules
 import org.kryptonmc.krypton.CURRENT_DIRECTORY
 import org.kryptonmc.krypton.KryptonServer
 import org.kryptonmc.krypton.ServerStorage
+import org.kryptonmc.krypton.auth.GameProfile
 import org.kryptonmc.krypton.entity.player.KryptonPlayer
+import org.kryptonmc.krypton.network.Session
 import org.kryptonmc.krypton.packet.Packet
-import org.kryptonmc.krypton.packet.out.status.ServerStatus
 import org.kryptonmc.krypton.packet.out.play.GameState
 import org.kryptonmc.krypton.packet.out.play.PacketOutAbilities
+import org.kryptonmc.krypton.packet.out.play.PacketOutAttributes
 import org.kryptonmc.krypton.packet.out.play.PacketOutChangeGameState
-import org.kryptonmc.krypton.packet.out.play.PacketOutDeclareCommands
+import org.kryptonmc.krypton.packet.out.play.PacketOutChangeHeldItem
 import org.kryptonmc.krypton.packet.out.play.PacketOutDeclareRecipes
 import org.kryptonmc.krypton.packet.out.play.PacketOutDestroyEntities
-import org.kryptonmc.krypton.packet.out.play.PacketOutHeadLook
-import org.kryptonmc.krypton.packet.out.play.PacketOutMetadata
-import org.kryptonmc.krypton.packet.out.play.PacketOutAttributes
 import org.kryptonmc.krypton.packet.out.play.PacketOutEntityStatus
-import org.kryptonmc.krypton.packet.out.play.PacketOutChangeHeldItem
+import org.kryptonmc.krypton.packet.out.play.PacketOutHeadLook
 import org.kryptonmc.krypton.packet.out.play.PacketOutInitializeWorldBorder
 import org.kryptonmc.krypton.packet.out.play.PacketOutJoinGame
 import org.kryptonmc.krypton.packet.out.play.PacketOutKeepAlive
+import org.kryptonmc.krypton.packet.out.play.PacketOutMetadata
 import org.kryptonmc.krypton.packet.out.play.PacketOutPlayerInfo
 import org.kryptonmc.krypton.packet.out.play.PacketOutPlayerPositionAndLook
 import org.kryptonmc.krypton.packet.out.play.PacketOutPluginMessage
@@ -56,7 +57,13 @@ import org.kryptonmc.krypton.packet.out.play.PacketOutUnlockRecipes
 import org.kryptonmc.krypton.packet.out.play.PacketOutUpdateViewPosition
 import org.kryptonmc.krypton.packet.out.play.PacketOutWindowItems
 import org.kryptonmc.krypton.packet.out.play.UnlockRecipesAction
-import org.kryptonmc.krypton.network.Session
+import org.kryptonmc.krypton.packet.out.status.ServerStatus
+import org.kryptonmc.krypton.server.ban.BannedIpList
+import org.kryptonmc.krypton.server.ban.BannedPlayerList
+import org.kryptonmc.krypton.server.op.OperatorEntry
+import org.kryptonmc.krypton.server.op.OperatorList
+import org.kryptonmc.krypton.server.whitelist.Whitelist
+import org.kryptonmc.krypton.server.whitelist.WhitelistedIps
 import org.kryptonmc.krypton.util.logger
 import org.kryptonmc.krypton.util.nextInt
 import org.kryptonmc.krypton.util.threadFactory
@@ -68,6 +75,7 @@ import org.kryptonmc.krypton.world.data.PlayerDataManager
 import org.spongepowered.math.GenericMath
 import org.spongepowered.math.vector.Vector3d
 import org.spongepowered.math.vector.Vector3i
+import java.nio.file.Path
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
@@ -79,116 +87,148 @@ import kotlin.random.Random
 
 class PlayerManager(private val server: KryptonServer) : ForwardingAudience {
 
-    private val dataManager = PlayerDataManager(CURRENT_DIRECTORY.resolve(server.config.world.name).resolve("playerdata"))
+    private val dataManager =
+        PlayerDataManager(CURRENT_DIRECTORY.resolve(server.config.world.name).resolve("playerdata"))
     private val keepAliveExecutor = Executors.newScheduledThreadPool(4, threadFactory("Keep Alive Scheduler"))
     val players = CopyOnWriteArrayList<KryptonPlayer>()
     val playersByName = ConcurrentHashMap<String, KryptonPlayer>()
     val playersByUUID = ConcurrentHashMap<UUID, KryptonPlayer>()
+    val userCache = UserCache(Path.of("usercache.json"))
 
     private val registryHolder = server.registryHolder
     private val maxPlayers = server.status.maxPlayers
     private val viewDistance = server.config.world.viewDistance
+    var whitelistEnabled = server.config.server.whitelistEnabled
+        set(value) {
+            field = value
+            server.config.server.whitelistEnabled = value
+            server.updateConfig()
+        }
+
+    val bannedPlayers = BannedPlayerList(Path.of("banned-players.json"))
+    val whitelist = Whitelist(Path.of("whitelist.json"))
+    val bannedIps = BannedIpList(Path.of("banned-ips.json"))
+    val ops = OperatorList(Path.of("ops.json"))
+    val whitlistedIps = WhitelistedIps(Path.of("whitelisted-ips.json"))
 
     val status = ServerStatus(server.status.motd, ServerStatus.Players(server.status.maxPlayers, players.size), null)
     private var lastStatus = 0L
 
-    fun add(player: KryptonPlayer, session: Session): CompletableFuture<Void> = dataManager.load(player).thenRun {
-        val profile = player.profile
+    fun add(player: KryptonPlayer, session: Session): CompletableFuture<Void> =
+        dataManager.load(player).thenRun {
+            val profile = player.profile
+            userCache.add(profile)
+            // Load the data
+            val world = server.worldManager.default
+            world.players += player
+            player.world = world
 
-        // Load the data
-        val world = server.worldManager.default
-        world.players += player
-        player.world = world
+            LOGGER.info("Player ${profile.name} logged in with entity ID ${player.id} at (${player.location.x}, ${player.location.y}, ${player.location.z})")
 
-        LOGGER.info("Player ${profile.name} logged in with entity ID ${player.id} at (${player.location.x}, ${player.location.y}, ${player.location.z})")
+            // Join the game
+            player.updateAbilities()
+            session.sendPacket(
+                PacketOutJoinGame(
+                    player.id,
+                    server.config.world.hardcore,
+                    world,
+                    server.registryHolder,
+                    player.gamemode,
+                    player.oldGamemode,
+                    world.dimensionType,
+                    maxPlayers,
+                    viewDistance
+                )
+            )
+            session.sendPacket(PacketOutPluginMessage(BRAND_KEY, BRAND_MESSAGE))
+            session.sendPacket(PacketOutServerDifficulty(server.difficulty))
 
-        // Join the game
-        player.updateAbilities()
-        session.sendPacket(PacketOutJoinGame(
-            player.id,
-            server.config.world.hardcore,
-            world,
-            server.registryHolder,
-            player.gamemode,
-            player.oldGamemode,
-            world.dimensionType,
-            maxPlayers,
-            viewDistance
-        ))
-        session.sendPacket(PacketOutPluginMessage(BRAND_KEY, BRAND_MESSAGE))
-        session.sendPacket(PacketOutServerDifficulty(server.difficulty))
+            // Player data stuff
+            session.sendPacket(PacketOutAbilities(player.abilities))
+            session.sendPacket(PacketOutChangeHeldItem(player.inventory.heldSlot))
+            sendCommands(player)
+            session.sendPacket(PacketOutDeclareRecipes)
+            session.sendPacket(PacketOutUnlockRecipes(UnlockRecipesAction.INIT))
+            session.sendPacket(PacketOutTags(server.resources.tags.write(registryHolder)))
+            session.sendPacket(
+                PacketOutEntityStatus(
+                    player.id,
+                    if (world.gameRules[GameRules.REDUCED_DEBUG_INFO]) 22 else 23
+                )
+            )
+            //sendOperatorStatus(player)
+            invalidateStatus()
 
-        // Player data stuff
-        session.sendPacket(PacketOutAbilities(player.abilities))
-        session.sendPacket(PacketOutChangeHeldItem(player.inventory.heldSlot))
-        session.sendPacket(PacketOutDeclareCommands(server.commandManager.dispatcher.root))
-        session.sendPacket(PacketOutDeclareRecipes)
-        session.sendPacket(PacketOutUnlockRecipes(UnlockRecipesAction.INIT))
-        session.sendPacket(PacketOutTags(server.resources.tags.write(registryHolder)))
-        session.sendPacket(PacketOutEntityStatus(player.id, if (world.gameRules[GameRules.REDUCED_DEBUG_INFO]) 22 else 23))
-        sendOperatorStatus(player)
-        invalidateStatus()
+            // Fire join event and send result message
+            val joinResult = server.eventManager.fireSync(JoinEvent(player)).result
+            if (!joinResult.isAllowed) {
+                // Use default reason if denied without specified reason
+                val reason = joinResult.reason.takeIf { it != Component.empty() }
+                    ?: Component.translatable("multiplayer.disconnect.kicked")
+                session.disconnect(reason)
+                return@thenRun
+            }
+            server.sendMessage(joinResult.reason)
+            session.sendPacket(PacketOutPlayerPositionAndLook(player.location))
 
-        // Fire join event and send result message
-        val joinResult = server.eventManager.fireSync(JoinEvent(player)).result
-        if (!joinResult.isAllowed) {
-            // Use default reason if denied without specified reason
-            val reason = joinResult.reason.takeIf { it != Component.empty() } ?: Component.translatable("multiplayer.disconnect.kicked")
-            session.disconnect(reason)
-            return@thenRun
+            // Update player list
+            sendToAll(PacketOutPlayerInfo(PacketOutPlayerInfo.PlayerAction.ADD_PLAYER, player))
+            session.sendPacket(PacketOutPlayerInfo(PacketOutPlayerInfo.PlayerAction.ADD_PLAYER, player))
+            session.sendPacket(PacketOutPlayerInfo(PacketOutPlayerInfo.PlayerAction.ADD_PLAYER, players))
+
+            // Send entity data
+            // TODO: Move this all to an entity manager
+            sendToAll(PacketOutSpawnPlayer(player))
+            players.forEach { session.sendPacket(PacketOutSpawnPlayer(it)) }
+            sendToAll(PacketOutMetadata(player.id, player.data.all))
+            players.forEach { session.sendPacket(PacketOutMetadata(it.id, it.data.all)) }
+            sendToAll(PacketOutAttributes(player.id, player.attributes.syncable))
+            players.forEach { session.sendPacket(PacketOutAttributes(it.id, it.attributes.syncable)) }
+            sendToAll(PacketOutHeadLook(player.id, player.location.yaw.toAngle()))
+            players.forEach { session.sendPacket(PacketOutHeadLook(it.id, it.location.yaw.toAngle())) }
+
+            // Add the player to the list and cache maps
+            players += player
+            playersByName[player.name] = player
+            playersByUUID[player.uuid] = player
+
+            // Send the initial chunk stream
+            val location = player.location
+            val centerChunk = ChunkPosition(GenericMath.floor(location.x / 16.0), GenericMath.floor(location.z / 16.0))
+            session.sendPacket(PacketOutUpdateViewPosition(centerChunk))
+            player.updateChunks()
+
+            // Send the world data
+            session.sendPacket(PacketOutInitializeWorldBorder(world.border))
+            session.sendPacket(PacketOutTimeUpdate(world.time, world.dayTime))
+            session.sendPacket(PacketOutSpawnPosition(world.spawnLocation, world.spawnAngle))
+            if (world.isRaining) {
+                session.sendPacket(PacketOutChangeGameState(GameState.BEGIN_RAINING))
+                session.sendPacket(PacketOutChangeGameState(GameState.RAIN_LEVEL_CHANGE, world.rainLevel))
+                session.sendPacket(PacketOutChangeGameState(GameState.THUNDER_LEVEL_CHANGE, world.thunderLevel))
+            }
+
+            // Send inventory data
+            val items = player.inventory.networkItems
+            session.sendPacket(
+                PacketOutWindowItems(
+                    player.inventory.id,
+                    player.inventory.incrementStateId(),
+                    items,
+                    player.inventory.mainHand
+                )
+            )
+
+            ServerStorage.PLAYER_COUNT.getAndIncrement()
+
+            keepAliveExecutor.scheduleAtFixedRate({
+                val keepAliveId = System.currentTimeMillis()
+                session.lastKeepAliveId = keepAliveId
+                session.sendPacket(PacketOutKeepAlive(keepAliveId))
+            }, 0, 20, TimeUnit.SECONDS)
+
         }
-        server.sendMessage(joinResult.reason)
-        session.sendPacket(PacketOutPlayerPositionAndLook(player.location))
 
-        // Update player list
-        sendToAll(PacketOutPlayerInfo(PacketOutPlayerInfo.PlayerAction.ADD_PLAYER, player))
-        session.sendPacket(PacketOutPlayerInfo(PacketOutPlayerInfo.PlayerAction.ADD_PLAYER, player))
-        session.sendPacket(PacketOutPlayerInfo(PacketOutPlayerInfo.PlayerAction.ADD_PLAYER, players))
-
-        // Send entity data
-        // TODO: Move this all to an entity manager
-        sendToAll(PacketOutSpawnPlayer(player))
-        players.forEach { session.sendPacket(PacketOutSpawnPlayer(it)) }
-        sendToAll(PacketOutMetadata(player.id, player.data.all))
-        players.forEach { session.sendPacket(PacketOutMetadata(it.id, it.data.all)) }
-        sendToAll(PacketOutAttributes(player.id, player.attributes.syncable))
-        players.forEach { session.sendPacket(PacketOutAttributes(it.id, it.attributes.syncable)) }
-        sendToAll(PacketOutHeadLook(player.id, player.location.yaw.toAngle()))
-        players.forEach { session.sendPacket(PacketOutHeadLook(it.id, it.location.yaw.toAngle())) }
-
-        // Add the player to the list and cache maps
-        players += player
-        playersByName[player.name] = player
-        playersByUUID[player.uuid] = player
-
-        // Send the initial chunk stream
-        val location = player.location
-        val centerChunk = ChunkPosition(GenericMath.floor(location.x / 16.0), GenericMath.floor(location.z / 16.0))
-        session.sendPacket(PacketOutUpdateViewPosition(centerChunk))
-        player.updateChunks()
-
-        // Send the world data
-        session.sendPacket(PacketOutInitializeWorldBorder(world.border))
-        session.sendPacket(PacketOutTimeUpdate(world.time, world.dayTime))
-        session.sendPacket(PacketOutSpawnPosition(world.spawnLocation, world.spawnAngle))
-        if (world.isRaining) {
-            session.sendPacket(PacketOutChangeGameState(GameState.BEGIN_RAINING))
-            session.sendPacket(PacketOutChangeGameState(GameState.RAIN_LEVEL_CHANGE, world.rainLevel))
-            session.sendPacket(PacketOutChangeGameState(GameState.THUNDER_LEVEL_CHANGE, world.thunderLevel))
-        }
-
-        // Send inventory data
-        val items = player.inventory.networkItems
-        session.sendPacket(PacketOutWindowItems(player.inventory.id, player.inventory.incrementStateId(), items, player.inventory.mainHand))
-
-        ServerStorage.PLAYER_COUNT.getAndIncrement()
-
-        keepAliveExecutor.scheduleAtFixedRate({
-            val keepAliveId = System.currentTimeMillis()
-            session.lastKeepAliveId = keepAliveId
-            session.sendPacket(PacketOutKeepAlive(keepAliveId))
-        }, 0, 20, TimeUnit.SECONDS)
-    }
 
     fun remove(player: KryptonPlayer) {
         server.eventManager.fire(QuitEvent(player)).thenAccept {
@@ -219,7 +259,15 @@ class PlayerManager(private val server: KryptonServer) : ForwardingAudience {
         if (it.world == world) it.session.sendPacket(packet)
     }
 
-    fun broadcast(packet: Packet, world: KryptonWorld, x: Double, y: Double, z: Double, radius: Double, except: KryptonPlayer) = players.forEach {
+    fun broadcast(
+        packet: Packet,
+        world: KryptonWorld,
+        x: Double,
+        y: Double,
+        z: Double,
+        radius: Double,
+        except: KryptonPlayer
+    ) = players.forEach {
         if (it == except || it.world != world) return@forEach
         val offsetX = x - it.location.x
         val offsetY = y - it.location.y
@@ -227,15 +275,56 @@ class PlayerManager(private val server: KryptonServer) : ForwardingAudience {
         if (offsetX * offsetX + offsetY * offsetY + offsetZ * offsetZ < radius * radius) it.session.sendPacket(packet)
     }
 
-    fun broadcast(packet: Packet, world: KryptonWorld, position: Vector3d, radius: Double, except: KryptonPlayer) = broadcast(packet, world, position.x(), position.y(), position.z(), radius, except)
+    fun broadcast(packet: Packet, world: KryptonWorld, position: Vector3d, radius: Double, except: KryptonPlayer) =
+        broadcast(packet, world, position.x(), position.y(), position.z(), radius, except)
 
-    fun broadcast(packet: Packet, world: KryptonWorld, position: Vector3i, radius: Double, except: KryptonPlayer) = broadcast(packet, world, position.x().toDouble(), position.y().toDouble(), position.z().toDouble(), radius, except)
+    fun broadcast(packet: Packet, world: KryptonWorld, position: Vector3i, radius: Double, except: KryptonPlayer) =
+        broadcast(
+            packet,
+            world,
+            position.x().toDouble(),
+            position.y().toDouble(),
+            position.z().toDouble(),
+            radius,
+            except
+        )
 
     fun disconnectAll() = players.forEach {
         it.session.disconnect(Component.translatable("multiplayer.disconnect.server_shutdown"))
     }
 
     private fun saveAll() = players.forEach { dataManager.save(it) }
+
+    fun addToOperators(profile: GameProfile) {
+        ops += OperatorEntry(profile, server.config.server.opPermissionLevel, true)
+        if (server.player(profile.uuid) != null) {
+            server.commandManager.sendCommands(server.player(profile.uuid)!!)
+        }
+    }
+
+    fun removeFromOperators(profile: GameProfile) {
+        ops -= profile
+        if (server.player(profile.uuid) != null) {
+            server.commandManager.sendCommands(server.player(profile.uuid)!!)
+        }
+    }
+
+    private fun sendCommands(player: KryptonPlayer) {
+        val permissionLevel = player.server.getPermissionLevel(player.profile)
+        sendCommands(player, permissionLevel.id)
+    }
+
+    private fun sendCommands(player: KryptonPlayer, permissionLevel: Int) {
+        val d: Int = if (permissionLevel <= 0) {
+            24
+        } else if (permissionLevel >= 4) {
+            28
+        } else {
+            (24 + permissionLevel)
+        }
+        player.session.sendPacket(PacketOutEntityStatus(player.id, d))
+        server.commandManager.sendCommands(player)
+    }
 
     fun shutdown() {
         saveAll()
@@ -255,10 +344,6 @@ class PlayerManager(private val server: KryptonServer) : ForwardingAudience {
 
     fun invalidateStatus() {
         lastStatus = 0L
-    }
-
-    private fun sendOperatorStatus(player: KryptonPlayer) {
-        // TODO: Get status from ops.json and send it to the client
     }
 
     override fun audiences() = players

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/ServerConfigEntry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/ServerConfigEntry.kt
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.server
+
+import com.google.gson.JsonObject
+
+abstract class ServerConfigEntry<T>(val key: T) {
+
+    open fun isInvalid() = false
+
+    internal abstract fun writeToJson(data: JsonObject)
+
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/ServerConfigList.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/ServerConfigList.kt
@@ -99,7 +99,7 @@ abstract class ServerConfigList<K, V : ServerConfigEntry<K>>(val path: Path) : I
         }
     }
 
-    fun validatePath() {
+    open fun validatePath() {
         if (!path.exists()) {
             path.createFile()
             path.writeText("[]")

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/ServerConfigList.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/ServerConfigList.kt
@@ -1,0 +1,101 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.server
+
+import com.google.gson.Gson
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import me.bardy.gsonkt.fromJson
+import java.nio.file.Path
+import kotlin.io.path.bufferedReader
+import kotlin.io.path.bufferedWriter
+import kotlin.io.path.createFile
+import kotlin.io.path.exists
+import kotlin.io.path.writeText
+
+abstract class ServerConfigList<K, V : ServerConfigEntry<K>>(val path: Path) : Iterable<V> {
+
+    private val map = hashMapOf<String, V>()
+    private val gson = Gson()
+    val size get() = map.values.size
+
+
+    open operator fun get(key: K) = map[key.toString()]
+
+    operator fun plusAssign(entry: V) = add(entry)
+
+    operator fun minusAssign(key: K) = remove(key)
+
+    override fun iterator(): Iterator<V> = map.values.iterator()
+
+    fun contains(key: K) = map.containsKey(key.toString())
+
+    fun isEmpty() = map.isEmpty()
+
+
+    fun add(entry: V) {
+        map[entry.key.toString()] = entry
+
+        save()
+    }
+
+    fun remove(key: K) {
+        map.remove(key.toString())
+
+        save()
+    }
+
+    internal abstract fun fromJson(data: JsonObject): ServerConfigEntry<K>
+
+    fun save() {
+        val players = JsonArray()
+
+        for (value in map.values) {
+            val data = JsonObject()
+            value.writeToJson(data)
+            players.add(data)
+        }
+
+        path.bufferedWriter(charset = Charsets.UTF_8).use {
+            gson.toJson(players, it)
+        }
+    }
+
+    fun load() {
+        map.clear()
+        path.bufferedReader(charset = Charsets.UTF_8).use {
+            val data = gson.fromJson<JsonArray>(it)
+            for (jsonEntry in data) {
+                val entry = jsonEntry as JsonObject
+                val serverConfigEntry = fromJson(entry)
+                map[serverConfigEntry.key.toString()] = serverConfigEntry as V
+            }
+        }
+    }
+
+    fun validatePath() {
+        if (!path.exists()) {
+            path.createFile()
+            path.writeText("[]")
+        } else {
+            load()
+        }
+    }
+
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/UserCache.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/UserCache.kt
@@ -122,6 +122,11 @@ class UserCache(private val path: Path) {
         }
     }
 
+    fun clear() {
+        entries.removeAll { it.expiryDate.isAfter(OffsetDateTime.now()) }
+        save()
+    }
+
     data class Entry(val profile: GameProfile, val expiryDate: OffsetDateTime = OffsetDateTime.now()) {
 
         internal fun writeToJson(data: JsonObject) {
@@ -155,6 +160,7 @@ class UserCache(private val path: Path) {
         } else {
             load()
         }
+        clear()
     }
 
     companion object {

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/UserCache.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/UserCache.kt
@@ -1,0 +1,165 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.server
+
+import com.google.gson.Gson
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import me.bardy.gsonkt.fromJson
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.kryptonmc.krypton.auth.GameProfile
+import org.kryptonmc.krypton.util.logger
+import java.nio.file.Path
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+import kotlin.io.path.bufferedReader
+import kotlin.io.path.bufferedWriter
+import kotlin.io.path.createFile
+import kotlin.io.path.exists
+import kotlin.io.path.writeText
+
+class UserCache(private val path: Path) {
+
+    private val client = OkHttpClient()
+    private val request: (String) -> Request = {
+        Request.Builder()
+            .url("https://api.mojang.com/users/profiles/minecraft/$it")
+            .get()
+            .build()
+    }
+    private val gson = Gson()
+    private val entries = mutableListOf<Entry>()
+    private val LOGGER = logger<UserCache>()
+
+    fun getProfileByName(name: String): GameProfile? {
+        val entry = entries.firstOrNull { it.profile.name == name }
+        return entry?.profile ?: findProfileByName(name)
+    }
+
+    fun getProfileByUUID(uuid: UUID): GameProfile? {
+        val entry = entries.firstOrNull { it.profile.uuid == uuid }
+        return entry?.profile
+    }
+
+    private fun findProfileByName(name: String): GameProfile? {
+        val result = client.newCall(request(name)).execute().body!!.string()
+        val data = gson.fromJson<JsonObject>(result) ?: return null
+        if (data.has("error")) return null
+        val gameProfile = GameProfile(
+            UUID.fromString(
+                StringBuilder(data.get("id").asString)
+                    .insert(20, '-')
+                    .insert(16, '-')
+                    .insert(12, '-')
+                    .insert(8, '-')
+                    .toString()
+            ), name, listOf()
+        )
+        entries.add(Entry(gameProfile, OffsetDateTime.now().plus(1, ChronoUnit.MONTHS)))
+        save()
+        return gameProfile
+    }
+
+    fun add(profile: GameProfile, expiryDate: OffsetDateTime = OffsetDateTime.now().plus(1, ChronoUnit.MONTHS)) {
+        if (entries.firstOrNull { it.profile == profile } == null) entries.add(Entry(profile, expiryDate))
+        save()
+    }
+
+    fun remove(entry: Entry) {
+        entries.remove(entry)
+        save()
+    }
+
+    fun load() {
+        entries.clear()
+        path.bufferedReader().use {
+            val array = gson.fromJson<JsonArray>(it)
+            for (jsonElement in array) {
+                val data = jsonElement as JsonObject
+                val entry = Entry.fromJson(data)
+                if (entry == null) {
+                    LOGGER.error("Couldn't parse user cache entry: $jsonElement")
+                } else {
+                    entries.add(entry)
+                }
+            }
+            entries.sortBy { entry ->
+                entry.expiryDate
+            }
+        }
+    }
+
+    fun save() {
+        val profiles = JsonArray()
+
+        for (entry in entries.take(1000)) {
+            val data = JsonObject()
+            entry.writeToJson(data)
+            profiles.add(data)
+        }
+
+        path.bufferedWriter().use {
+            gson.toJson(profiles, it)
+        }
+    }
+
+    data class Entry(val profile: GameProfile, val expiryDate: OffsetDateTime = OffsetDateTime.now()) {
+
+        internal fun writeToJson(data: JsonObject) {
+            data.addProperty("name", profile.name)
+            data.addProperty("uuid", profile.uuid.toString())
+            data.addProperty("expiresOn", DATE_FORMAT.format(expiryDate))
+        }
+
+        companion object {
+
+            fun fromJson(data: JsonObject): Entry? {
+                val nameElement = data.get("name")?.asString ?: return null
+                val uuidElement = data.get("uuid")?.asString ?: return null
+                val uuid = UUID.fromString(uuidElement)
+                val expiredDateElement = data.get("expiresOn")?.asString
+                val expiredDate = OffsetDateTime.from(
+                    if (expiredDateElement != null) DATE_FORMAT.parse(expiredDateElement) else OffsetDateTime.now()
+                        .plus(1, ChronoUnit.MONTHS)
+                )
+                return Entry(GameProfile(uuid, nameElement, listOf()), expiredDate)
+            }
+
+        }
+
+    }
+
+    fun validatePath() {
+        if (!path.exists()) {
+            path.createFile()
+            path.writeText("[]")
+        } else {
+            load()
+        }
+    }
+
+    companion object {
+
+        val DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z")
+    }
+
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/ban/BanEntry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/ban/BanEntry.kt
@@ -1,0 +1,76 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.server.ban
+
+import com.google.gson.JsonObject
+import org.kryptonmc.krypton.server.ServerConfigEntry
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+
+open class BanEntry<T>(
+    key: T,
+    val creationDate: OffsetDateTime = OffsetDateTime.now(),
+    val source: String = "(Unknown)",
+    val expiryDate: OffsetDateTime? = null,
+    val reason: String = "Banned by operator."
+) : ServerConfigEntry<T>(key) {
+
+
+    override fun isInvalid(): Boolean {
+        return expiryDate?.isBefore(OffsetDateTime.now()) ?: false
+    }
+
+    override fun writeToJson(data: JsonObject) {
+        data.addProperty("created", creationDate.format(DATE_FORMAT))
+        data.addProperty("source", source)
+        data.addProperty("expires", expiryDate?.format(DATE_FORMAT) ?: "forever")
+        data.addProperty("reason", reason)
+    }
+
+    companion object {
+
+        internal val DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z")
+
+        internal fun <T> fromJson(key: T, data: JsonObject): BanEntry<T> {
+            val creationDate = try {
+                if (data.has("created")) DATE_FORMAT.parse(data.get("created").asString) else LocalDateTime.now()
+            } catch (_: DateTimeParseException) {
+                LocalDateTime.now()
+            }
+            val source = if (data.has("source")) data.get("source").asString else "(Unknown)"
+            val expires = try {
+                if (data.has("expires")) DATE_FORMAT.parse(data.get("expires").asString) else null
+            } catch (_: DateTimeParseException) {
+                null
+            }
+            val reason = if (data.has("reason")) data.get("reason").asString else "Banned by operator."
+            return BanEntry(
+                key,
+                OffsetDateTime.from(creationDate),
+                source,
+                if (expires == null) null else OffsetDateTime.from(expires),
+                reason
+            )
+        }
+
+    }
+
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/ban/BannedIpEntry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/ban/BannedIpEntry.kt
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.server.ban
+
+import com.google.gson.JsonObject
+import java.time.OffsetDateTime
+
+class BannedIpEntry(
+    ip: String,
+    creationDate: OffsetDateTime = OffsetDateTime.now(),
+    source: String = "(Unknown)",
+    expiryDate: OffsetDateTime? = null,
+    reason: String = "Banned by operator."
+) : BanEntry<String>(ip, creationDate, source, expiryDate, reason) {
+
+    override fun writeToJson(data: JsonObject) {
+        data.addProperty("ip", key)
+        super.writeToJson(data)
+    }
+
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/ban/BannedIpList.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/ban/BannedIpList.kt
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.server.ban
+
+import com.google.gson.JsonObject
+import org.kryptonmc.krypton.server.ServerConfigList
+import org.kryptonmc.krypton.util.stringify
+import java.net.SocketAddress
+import java.nio.file.Path
+
+class BannedIpList(path: Path) : ServerConfigList<String, BannedIpEntry>(path) {
+
+    override fun fromJson(data: JsonObject): BannedIpEntry {
+        val entry = BanEntry.fromJson(data.get("ip").asString, data) //Get better null checking
+        return BannedIpEntry(entry.key!!, entry.creationDate, entry.source, entry.expiryDate, entry.reason)
+    }
+
+    fun isBanned(adress: SocketAddress) = contains(adress.stringify())
+
+    operator fun get(key: SocketAddress) = super.get(key.stringify())
+
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/ban/BannedIpList.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/ban/BannedIpList.kt
@@ -23,6 +23,7 @@ import org.kryptonmc.krypton.server.ServerConfigList
 import org.kryptonmc.krypton.util.stringify
 import java.net.SocketAddress
 import java.nio.file.Path
+import java.time.OffsetDateTime
 
 class BannedIpList(path: Path) : ServerConfigList<String, BannedIpEntry>(path) {
 
@@ -32,6 +33,20 @@ class BannedIpList(path: Path) : ServerConfigList<String, BannedIpEntry>(path) {
     }
 
     fun isBanned(adress: SocketAddress) = contains(adress.stringify())
+
+    fun clear() {
+        forEach {
+            it.expiryDate?.let { time ->
+                if(time.isAfter(OffsetDateTime.now())) remove(it.key)
+            }
+        }
+        save()
+    }
+
+    override fun validatePath() {
+        super.validatePath()
+        clear()
+    }
 
     operator fun get(key: SocketAddress) = super.get(key.stringify())
 

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/ban/BannedIpList.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/ban/BannedIpList.kt
@@ -40,7 +40,6 @@ class BannedIpList(path: Path) : ServerConfigList<String, BannedIpEntry>(path) {
                 if(time.isAfter(OffsetDateTime.now())) remove(it.key)
             }
         }
-        save()
     }
 
     override fun validatePath() {

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/ban/BannedPlayerEntry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/ban/BannedPlayerEntry.kt
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.server.ban
+
+import com.google.gson.JsonObject
+import org.kryptonmc.krypton.auth.GameProfile
+import java.time.OffsetDateTime
+
+class BannedPlayerEntry(
+    profile: GameProfile,
+    creationDate: OffsetDateTime = OffsetDateTime.now(),
+    source: String = "(Unknown)",
+    expiryDate: OffsetDateTime? = null,
+    reason: String = "Banned by operator."
+) : BanEntry<GameProfile>(profile, creationDate, source, expiryDate, reason) {
+
+    override fun writeToJson(data: JsonObject) {
+        data.addProperty("uuid", key.uuid.toString())
+        data.addProperty("name", key.name)
+        super.writeToJson(data)
+    }
+
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/ban/BannedPlayerList.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/ban/BannedPlayerList.kt
@@ -27,8 +27,8 @@ import java.nio.file.Path
 class BannedPlayerList(path: Path) : ServerConfigList<GameProfile, BannedPlayerEntry>(path) {
 
     override fun fromJson(data: JsonObject): BannedPlayerEntry {
-        val entry = BanEntry.fromJson(data.toGameProfile(), data) //Get better null checking
-        return BannedPlayerEntry(entry.key!!, entry.creationDate, entry.source, entry.expiryDate, entry.reason)
+        val entry = BanEntry.fromJson(data.toGameProfile(), data)
+        return BannedPlayerEntry(entry.key, entry.creationDate, entry.source, entry.expiryDate, entry.reason)
     }
 
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/ban/BannedPlayerList.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/ban/BannedPlayerList.kt
@@ -23,12 +23,27 @@ import org.kryptonmc.krypton.auth.GameProfile
 import org.kryptonmc.krypton.server.ServerConfigList
 import org.kryptonmc.krypton.util.toGameProfile
 import java.nio.file.Path
+import java.time.OffsetDateTime
 
 class BannedPlayerList(path: Path) : ServerConfigList<GameProfile, BannedPlayerEntry>(path) {
 
-    override fun fromJson(data: JsonObject): BannedPlayerEntry {
+    override fun fromJson(data: JsonObject): BannedPlayerEntry? {
         val entry = BanEntry.fromJson(data.toGameProfile(), data)
-        return BannedPlayerEntry(entry.key, entry.creationDate, entry.source, entry.expiryDate, entry.reason)
+        return entry.key?.let { BannedPlayerEntry(it, entry.creationDate, entry.source, entry.expiryDate, entry.reason) }
+    }
+
+    fun clear() {
+        forEach {
+            it.expiryDate?.let { time ->
+                if(time.isAfter(OffsetDateTime.now())) remove(it.key)
+            }
+        }
+        save()
+    }
+
+    override fun validatePath() {
+        super.validatePath()
+        clear()
     }
 
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/ban/BannedPlayerList.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/ban/BannedPlayerList.kt
@@ -38,7 +38,6 @@ class BannedPlayerList(path: Path) : ServerConfigList<GameProfile, BannedPlayerE
                 if(time.isAfter(OffsetDateTime.now())) remove(it.key)
             }
         }
-        save()
     }
 
     override fun validatePath() {

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/ban/BannedPlayerList.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/ban/BannedPlayerList.kt
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.server.ban
+
+import com.google.gson.JsonObject
+import org.kryptonmc.krypton.auth.GameProfile
+import org.kryptonmc.krypton.server.ServerConfigList
+import org.kryptonmc.krypton.util.toGameProfile
+import java.nio.file.Path
+
+class BannedPlayerList(path: Path) : ServerConfigList<GameProfile, BannedPlayerEntry>(path) {
+
+    override fun fromJson(data: JsonObject): BannedPlayerEntry {
+        val entry = BanEntry.fromJson(data.toGameProfile(), data) //Get better null checking
+        return BannedPlayerEntry(entry.key!!, entry.creationDate, entry.source, entry.expiryDate, entry.reason)
+    }
+
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/op/OperatorEntry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/op/OperatorEntry.kt
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.server.op
+
+import com.google.gson.JsonObject
+import org.kryptonmc.krypton.auth.GameProfile
+import org.kryptonmc.krypton.server.ServerConfigEntry
+
+class OperatorEntry(profile: GameProfile, val permissionLevel: Int, val bypassPlayerLimit: Boolean) :
+    ServerConfigEntry<GameProfile>(profile) {
+
+    override fun writeToJson(data: JsonObject) {
+        data.addProperty("uuid", key.uuid.toString())
+        data.addProperty("name", key.name)
+        data.addProperty("level", permissionLevel)
+        data.addProperty("bypassesPlayerLimit", bypassPlayerLimit)
+    }
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/op/OperatorList.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/op/OperatorList.kt
@@ -27,11 +27,11 @@ import java.nio.file.Path
 
 class OperatorList(path: Path) : ServerConfigList<GameProfile, OperatorEntry>(path) {
 
-    override fun fromJson(data: JsonObject): ServerConfigEntry<GameProfile> {
-        val profile = data.toGameProfile()!!
+    override fun fromJson(data: JsonObject): ServerConfigEntry<GameProfile>? {
+        val profile = data.toGameProfile()
         val permissionLevel = data.get("level")?.asInt ?: 0
         val bypassesPlayerLimit = data.has("bypassesPlayerLimit") && data.get("bypassesPlayerLimit").asBoolean
-        return OperatorEntry(profile, permissionLevel, bypassesPlayerLimit)
+        return profile?.let { OperatorEntry(it, permissionLevel, bypassesPlayerLimit) }
     }
 
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/op/OperatorList.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/op/OperatorList.kt
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.server.op
+
+import com.google.gson.JsonObject
+import org.kryptonmc.krypton.auth.GameProfile
+import org.kryptonmc.krypton.server.ServerConfigEntry
+import org.kryptonmc.krypton.server.ServerConfigList
+import org.kryptonmc.krypton.util.toGameProfile
+import java.nio.file.Path
+
+class OperatorList(path: Path) : ServerConfigList<GameProfile, OperatorEntry>(path) {
+
+    override fun fromJson(data: JsonObject): ServerConfigEntry<GameProfile> {
+        val profile = data.toGameProfile()!!
+        val permissionLevel = data.get("level")?.asInt ?: 0
+        val bypassesPlayerLimit = data.has("bypassesPlayerLimit") && data.get("bypassesPlayerLimit").asBoolean
+        return OperatorEntry(profile, permissionLevel, bypassesPlayerLimit)
+    }
+
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/whitelist/Whitelist.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/whitelist/Whitelist.kt
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.server.whitelist
+
+import com.google.gson.JsonObject
+import org.kryptonmc.krypton.auth.GameProfile
+import org.kryptonmc.krypton.server.ServerConfigList
+import org.kryptonmc.krypton.util.toGameProfile
+import java.nio.file.Path
+
+class Whitelist(path: Path) : ServerConfigList<GameProfile, WhitelistEntry>(path) {
+
+    override fun fromJson(data: JsonObject): WhitelistEntry {
+        return WhitelistEntry(data.toGameProfile()!!)
+    }
+
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/whitelist/Whitelist.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/whitelist/Whitelist.kt
@@ -26,8 +26,8 @@ import java.nio.file.Path
 
 class Whitelist(path: Path) : ServerConfigList<GameProfile, WhitelistEntry>(path) {
 
-    override fun fromJson(data: JsonObject): WhitelistEntry {
-        return WhitelistEntry(data.toGameProfile()!!)
+    override fun fromJson(data: JsonObject): WhitelistEntry? {
+        return data.toGameProfile()?.let { WhitelistEntry(it) }
     }
 
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/whitelist/WhitelistEntry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/whitelist/WhitelistEntry.kt
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.server.whitelist
+
+import com.google.gson.JsonObject
+import org.kryptonmc.krypton.auth.GameProfile
+import org.kryptonmc.krypton.server.ServerConfigEntry
+
+class WhitelistEntry(key: GameProfile) : ServerConfigEntry<GameProfile>(key) {
+
+    override fun writeToJson(data: JsonObject) {
+        data.addProperty("name", key.name)
+        data.addProperty("uuid", key.uuid.toString())
+    }
+
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/whitelist/WhitelistIpEntry.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/whitelist/WhitelistIpEntry.kt
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.server.whitelist
+
+import com.google.gson.JsonObject
+import org.kryptonmc.krypton.server.ServerConfigEntry
+
+class WhitelistIpEntry(ip: String) : ServerConfigEntry<String>(ip) {
+
+    override fun writeToJson(data: JsonObject) {
+        data.addProperty("ip", key)
+    }
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/whitelist/WhitelistedIps.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/whitelist/WhitelistedIps.kt
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.server.whitelist
+
+import com.google.gson.JsonObject
+import org.kryptonmc.krypton.server.ServerConfigList
+import java.net.SocketAddress
+import java.nio.file.Path
+
+class WhitelistedIps(path: Path) : ServerConfigList<String, WhitelistIpEntry>(path) {
+
+    override fun fromJson(data: JsonObject) = WhitelistIpEntry(data.get("ip").asString)
+
+    fun isWhitelisted(adress: SocketAddress) = contains(stringifyAddress(adress))
+
+    operator fun get(key: SocketAddress) = super.get(stringifyAddress(key))
+
+    private fun stringifyAddress(socketAddress: SocketAddress): String {
+        var string = socketAddress.toString()
+        if (string.contains("/")) {
+            string = string.substring(string.indexOf(47.toChar()) + 1)
+        }
+        if (string.contains(":")) {
+            string = string.substring(0, string.indexOf(58.toChar()))
+        }
+        return string
+    }
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/util/utils.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/util/utils.kt
@@ -19,16 +19,42 @@
 package org.kryptonmc.krypton.util
 
 import com.google.common.net.InetAddresses
+import com.google.gson.JsonObject
 import it.unimi.dsi.fastutil.Hash
+import net.kyori.adventure.text.Component.text
+import org.kryptonmc.krypton.auth.GameProfile
 import java.math.BigInteger
 import java.net.InetAddress
+import java.net.SocketAddress
 import java.security.AccessController
 import java.security.MessageDigest
 import java.security.PrivilegedAction
 import java.util.Optional
+import java.util.UUID
 
 // Avoid lookups
 fun String.toInetAddress(): InetAddress = InetAddresses.forString(this)
+
+fun SocketAddress.stringify(): String {
+    var string = toString()
+    if (string.contains("/")) {
+        string = string.substring(string.indexOf(47.toChar()) + 1)
+    }
+    if (string.contains(":")) {
+        string = string.substring(0, string.indexOf(58.toChar()))
+    }
+    return string
+}
+
+fun String.toIntRange(): IntRange? {
+    return if (startsWith("..")) {
+        val string = replace("..", "").toIntOrNull() ?: return null
+        IntRange(0, string)
+    } else {
+        val values = split("..")
+        IntRange(values[0].toInt(), values[1].toIntOrNull() ?: return null)
+    }
+}
 
 fun calculatePositionChange(new: Double, old: Double) = ((new * 32 - old * 32) * 128).toInt().toShort()
 
@@ -40,6 +66,21 @@ fun <T> doPrivileged(action: () -> T): T = AccessController.doPrivileged(Privile
 fun notSupported(message: String): Nothing = throw UnsupportedOperationException(message)
 
 fun <T : Map<K, V>, K, V> Optional<T>.forEachPresent(action: (K, V) -> Unit) = ifPresent { it.forEach(action) }
+
+fun String.toComponent() = text(this)
+
+fun JsonObject.toGameProfile(): GameProfile? {
+    if (has("name") && has("uuid")) {
+        val name = get("name").asString
+        val uuid = try {
+            UUID.fromString(get("uuid").asString)
+        } catch (_: IllegalArgumentException) {
+            return null
+        }
+        return GameProfile(uuid, name, listOf())
+    }
+    return null
+}
 
 @Suppress("UNCHECKED_CAST")
 fun <K> identityStrategy(): Hash.Strategy<K> = IdentityStrategy as Hash.Strategy<K>

--- a/server/src/main/kotlin/org/kryptonmc/krypton/world/KryptonWorld.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/world/KryptonWorld.kt
@@ -91,7 +91,7 @@ data class KryptonWorld(
     override val border: KryptonWorldBorder,
     var clearWeatherTime: Int,
     var dayTime: Long,
-    override val difficulty: Difficulty,
+    override var difficulty: Difficulty,
     //val endDimensionData: EndDimensionData, // for the end, when it is supported
     override val gameRules: GameRuleHolder,
     val generationSettings: WorldGenerationSettings,


### PR DESCRIPTION
This pull requests is mainly focused on more vanilla commands and adds the EntityArgument (+ some Commands around the EntityArgument).

**Features:**

- [x] Finish EntityArgument
- [x] Add Say Command
- [x] Add Seed Command
- [x] Add List Command
- [x] Finish new Gamemode Command
- [x] Add target selectors to teleport command
- [x] Add Msg/Tell command
- [x] Add Me Command
- [x] Add Title Command
- [x] Add Version Command
- [x] Add GameRule Command
- [x] Add Difficulty Command
- [x] Add Kick Command
- [x] Add GameProfile Argument Type
- [x] Add Ban System
- [x] Add Whitelist System
- [x] Add Op System

**This is what adding a command with an EntityArgument will probably look like:**

```kotlin
dispatcher.register(literal<Sender>("test").then(argument<Sender, EntityQuery>("targets", EntityArgument.players())
   .executes {
        val source = it.source as? KryptonPlayer ?: return@executes 1
        val entities = it.entityArgument("targets").getEntities(source)  //probably also .getPlayers(), .getPlayer() and .getEntity()                   
        1
}))
```