### PR TITLE
Add ItemStackArgument(s)

### DIFF
--- a/api/src/main/kotlin/org/kryptonmc/api/item/meta/MetaKeys.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/item/meta/MetaKeys.kt
@@ -27,6 +27,7 @@ object MetaKeys {
     @JvmField val NAME = of<Component>("display/name")
     @JvmField val LORE = of<List<Component>>("display/lore")
     @JvmField val COLOR = of<Color>("display/color")
+    @JvmField val REPAIR_COST = of<Int>("repair_cost")
 
     @JvmField val HIDE_ATTRIBUTES = of<Boolean>("hide_attributes")
     @JvmField val HIDE_CAN_DESTROY = of<Boolean>("hide_can_destroy")

--- a/api/src/main/kotlin/org/kryptonmc/api/item/meta/MetaKeys.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/item/meta/MetaKeys.kt
@@ -27,7 +27,6 @@ object MetaKeys {
     @JvmField val NAME = of<Component>("display/name")
     @JvmField val LORE = of<List<Component>>("display/lore")
     @JvmField val COLOR = of<Color>("display/color")
-    @JvmField val REPAIR_COST = of<Int>("repair_cost")
 
     @JvmField val HIDE_ATTRIBUTES = of<Boolean>("hide_attributes")
     @JvmField val HIDE_CAN_DESTROY = of<Boolean>("hide_can_destroy")

--- a/server/src/main/kotlin/org/kryptonmc/krypton/KryptonServer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/KryptonServer.kt
@@ -54,6 +54,7 @@ import org.kryptonmc.krypton.packet.out.play.PacketOutServerDifficulty
 import org.kryptonmc.krypton.packet.out.play.PacketOutTimeUpdate
 import org.kryptonmc.krypton.plugin.KryptonEventManager
 import org.kryptonmc.krypton.plugin.KryptonPluginManager
+import org.kryptonmc.krypton.registry.InternalRegistries
 import org.kryptonmc.krypton.registry.KryptonRegistryManager
 import org.kryptonmc.krypton.registry.RegistryHolder
 import org.kryptonmc.krypton.registry.json.RegistryBlock

--- a/server/src/main/kotlin/org/kryptonmc/krypton/auth/KryptonGameProfile.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/auth/KryptonGameProfile.kt
@@ -29,7 +29,11 @@ data class KryptonGameProfile(
     @SerializedName("id") override val uuid: UUID,
     override val name: String,
     override val properties: List<KryptonProfileProperty>
-) : GameProfile
+) : GameProfile {
+
+    override fun toString() = "GameProfile(name=$name,uuid=$uuid)"
+
+}
 
 object MojangUUIDTypeAdapter : TypeAdapter<UUID>() {
 

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/KryptonCommandManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/KryptonCommandManager.kt
@@ -37,11 +37,13 @@ import org.kryptonmc.api.command.meta.SimpleCommandMeta
 import org.kryptonmc.krypton.KryptonServer
 import org.kryptonmc.krypton.command.commands.BanCommand
 import org.kryptonmc.krypton.command.commands.BanIpCommand
+import org.kryptonmc.krypton.command.commands.ClearCommand
 import org.kryptonmc.krypton.command.commands.DebugCommand
 import org.kryptonmc.krypton.command.commands.DeopCommand
 import org.kryptonmc.krypton.command.commands.DifficultyCommand
 import org.kryptonmc.krypton.command.commands.GamemodeCommand
 import org.kryptonmc.krypton.command.commands.GameruleCommand
+import org.kryptonmc.krypton.command.commands.GiveCommand
 import org.kryptonmc.krypton.command.commands.KickCommand
 import org.kryptonmc.krypton.command.commands.ListCommand
 import org.kryptonmc.krypton.command.commands.MeCommand
@@ -63,6 +65,7 @@ import org.kryptonmc.krypton.command.registrar.RawCommandRegistrar
 import org.kryptonmc.krypton.command.registrar.SimpleCommandRegistrar
 import org.kryptonmc.krypton.entity.player.KryptonPlayer
 import org.kryptonmc.krypton.packet.out.play.PacketOutDeclareCommands
+import org.kryptonmc.krypton.util.toComponent
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.locks.ReentrantReadWriteLock
 
@@ -143,6 +146,8 @@ class KryptonCommandManager(server: KryptonServer) : CommandManager {
         PardonIpCommand.register(dispatcher)
         OpCommand.register(dispatcher)
         DeopCommand.register(dispatcher)
+        GiveCommand.register(dispatcher)
+        ClearCommand.register(dispatcher)
     }
 
     private fun parse(sender: Sender, input: String): ParseResults<Sender> {

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/KryptonSender.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/KryptonSender.kt
@@ -39,11 +39,11 @@ abstract class KryptonSender(override val server: KryptonServer) : Sender {
 
     override fun grant(permission: String) {
         permissions[permission] = true
-        if (this is KryptonPlayer) server.commandManager.sendCommands(this)
+        if (this is KryptonPlayer) server.playerManager.sendCommands(this)
     }
 
     override fun revoke(permission: String) {
         permissions[permission] = false
-        if (this is KryptonPlayer) server.commandManager.sendCommands(this)
+        if (this is KryptonPlayer) server.playerManager.sendCommands(this)
     }
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/ArgumentTypes.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/ArgumentTypes.kt
@@ -36,6 +36,7 @@ import org.kryptonmc.krypton.command.arguments.NBTArgument
 import org.kryptonmc.krypton.command.arguments.NBTCompoundArgument
 import org.kryptonmc.krypton.command.arguments.SummonEntityArgument
 import org.kryptonmc.krypton.command.arguments.VectorArgument
+import org.kryptonmc.krypton.command.arguments.itemstack.ItemStackArgumentType
 import org.kryptonmc.krypton.locale.Messages
 import org.kryptonmc.krypton.util.logger
 import org.kryptonmc.krypton.util.writeKey
@@ -69,6 +70,7 @@ object ArgumentTypes {
         register<VectorArgument>("vec3", EmptyArgumentSerializer())
         register("entity", EntityArgumentSerializer())
         register<GameProfileArgument>("game_profile", EmptyArgumentSerializer())
+        register<ItemStackArgumentType>("item_stack", EmptyArgumentSerializer())
     }
 
     operator fun get(key: Key) = BY_NAME[key]

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/ArgumentTypes.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/argument/ArgumentTypes.kt
@@ -37,6 +37,7 @@ import org.kryptonmc.krypton.command.arguments.NBTCompoundArgument
 import org.kryptonmc.krypton.command.arguments.SummonEntityArgument
 import org.kryptonmc.krypton.command.arguments.VectorArgument
 import org.kryptonmc.krypton.command.arguments.itemstack.ItemStackArgumentType
+import org.kryptonmc.krypton.command.arguments.itemstack.ItemStackPredicateArgument
 import org.kryptonmc.krypton.locale.Messages
 import org.kryptonmc.krypton.util.logger
 import org.kryptonmc.krypton.util.writeKey
@@ -71,6 +72,7 @@ object ArgumentTypes {
         register("entity", EntityArgumentSerializer())
         register<GameProfileArgument>("game_profile", EmptyArgumentSerializer())
         register<ItemStackArgumentType>("item_stack", EmptyArgumentSerializer())
+        register<ItemStackPredicateArgument>("item_predicate", EmptyArgumentSerializer())
     }
 
     operator fun get(key: Key) = BY_NAME[key]

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/itemstack/ItemStackArgument.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/itemstack/ItemStackArgument.kt
@@ -1,5 +1,56 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command.arguments.itemstack
 
+import com.mojang.brigadier.context.CommandContext
+import org.kryptonmc.api.item.ItemStack
 import org.kryptonmc.api.item.ItemType
+import org.kryptonmc.krypton.KryptonServer
+import org.kryptonmc.krypton.item.KryptonItemStack
+import org.kryptonmc.nbt.CompoundTag
+import org.kryptonmc.nbt.IntTag
+import org.kryptonmc.nbt.StringTag
 
-data class ItemStackArgument(val item: ItemType)
+data class ItemStackArgument(val item: ItemType, val tag: CompoundTag? = null) {
+
+    fun createItemStacks(amount: Int, server: KryptonServer): List<ItemStack> {
+        val items = mutableListOf<ItemStack>()
+        if (amount <= item.maximumAmount) {
+            items.add(KryptonItemStack(addTag(amount)))
+        } else {
+            var size = amount
+            while (size > item.maximumAmount) {
+                items.add(KryptonItemStack(addTag(item.maximumAmount)))
+                size -= item.maximumAmount
+            }
+            items.add(KryptonItemStack(addTag(amount)))
+        }
+        return items
+    }
+
+    private fun addTag(amount: Int) = CompoundTag(
+        mutableMapOf(
+            "id" to StringTag.of(item.key.toString()),
+            "Count" to IntTag.of(amount),
+        ).also {
+            if (tag != null) it["tag"] = tag
+        }
+    )
+
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/itemstack/ItemStackArgument.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/itemstack/ItemStackArgument.kt
@@ -1,0 +1,5 @@
+package org.kryptonmc.krypton.command.arguments.itemstack
+
+import org.kryptonmc.api.item.ItemType
+
+data class ItemStackArgument(val item: ItemType)

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/itemstack/ItemStackArgumentType.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/itemstack/ItemStackArgumentType.kt
@@ -1,0 +1,15 @@
+package org.kryptonmc.krypton.command.arguments.itemstack
+
+import com.mojang.brigadier.StringReader
+import com.mojang.brigadier.arguments.ArgumentType
+import com.mojang.brigadier.context.CommandContext
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.util.argument
+
+class ItemStackArgumentType : ArgumentType<ItemStackArgument> {
+
+    override fun parse(reader: StringReader) = ItemStackParser(reader, false).parse()
+
+}
+
+fun CommandContext<Sender>.itemStackArgument(name: String) = argument<ItemStackArgument>(name)

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/itemstack/ItemStackArgumentType.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/itemstack/ItemStackArgumentType.kt
@@ -31,7 +31,7 @@ class ItemStackArgumentType : ArgumentType<ItemStackArgument> {
     override fun parse(reader: StringReader) = ItemStackParser(reader, false).parseItem()
 
     companion object {
-        val EXAMPLES = listOf("minecraft:cookie", "cookie", "cookie{foo=bar}")
+        private val EXAMPLES = listOf("minecraft:cookie", "cookie", "cookie{foo=bar}")
     }
 
 }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/itemstack/ItemStackParser.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/itemstack/ItemStackParser.kt
@@ -1,0 +1,43 @@
+package org.kryptonmc.krypton.command.arguments.itemstack
+
+import com.mojang.brigadier.StringReader
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
+import net.kyori.adventure.key.Key.key
+import net.kyori.adventure.text.Component.translatable
+import org.kryptonmc.api.adventure.toMessage
+import org.kryptonmc.api.item.ItemType
+import org.kryptonmc.api.registry.Registries
+import org.kryptonmc.krypton.util.toComponent
+import org.kryptonmc.nbt.CompoundTag
+
+class ItemStackParser(val reader: StringReader, val allowTags: Boolean) { //TODO: Tags for ItemStackPredicate etc.
+
+    val ID_INVALID_EXCEPTION = DynamicCommandExceptionType {e ->
+        translatable(
+            "argument.item.id.invalid",
+            listOf(e.toString().toComponent())
+        ).toMessage()
+    }
+    val TAG_DISALLOWED_EXCEPTION = SimpleCommandExceptionType(translatable("argument.item.tag.disallowed").toMessage())
+
+
+    fun readItem(reader: StringReader) : ItemType {
+        val i = reader.cursor
+
+        while (reader.canRead() && isCharValid(reader.peek())) {
+            reader.skip()
+        }
+
+        val string = reader.string.substring(i, reader.cursor)
+        val item = Registries.ITEM[key(string)] //TODO: Check if exist
+        return item
+    }
+
+    fun parse() = ItemStackArgument(readItem(this.reader))
+
+    fun isCharValid(c: Char): Boolean {
+        return c in '0'..'9' || c in 'a'..'z' || c == '_' || c == ':' || c == '/' || c == '.' || c == '-'
+    }
+
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/itemstack/ItemStackPredicateArgument.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/itemstack/ItemStackPredicateArgument.kt
@@ -22,18 +22,16 @@ import com.mojang.brigadier.StringReader
 import com.mojang.brigadier.arguments.ArgumentType
 import com.mojang.brigadier.context.CommandContext
 import org.kryptonmc.api.command.Sender
-import org.kryptonmc.krypton.util.argument
+import org.kryptonmc.api.item.ItemStack
 
-class ItemStackArgumentType : ArgumentType<ItemStackArgument> {
+class ItemStackPredicateArgument : ArgumentType<ItemStackPredicate> {
 
-    override fun getExamples() = EXAMPLES
-
-    override fun parse(reader: StringReader) = ItemStackParser(reader, false).parseItem()
-
-    companion object {
-        val EXAMPLES = listOf("minecraft:cookie", "cookie", "cookie{foo=bar}")
-    }
+    override fun parse(reader: StringReader) = ItemStackParser(reader, true).parsePredicate()
 
 }
 
-fun CommandContext<Sender>.itemStackArgument(name: String) = argument<ItemStackArgument>(name)
+fun interface ItemStackPredicate {
+
+    operator fun invoke(item: ItemStack) : Boolean
+
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/itemstack/ItemStackPredicateArgument.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/itemstack/ItemStackPredicateArgument.kt
@@ -26,6 +26,8 @@ import org.kryptonmc.api.item.ItemStack
 
 class ItemStackPredicateArgument : ArgumentType<ItemStackPredicate> {
 
+    override fun getExamples() = EXAMPLES
+
     override fun parse(reader: StringReader) = ItemStackParser(reader, true).parsePredicate()
 
     companion object {

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/itemstack/ItemStackPredicateArgument.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/arguments/itemstack/ItemStackPredicateArgument.kt
@@ -28,6 +28,12 @@ class ItemStackPredicateArgument : ArgumentType<ItemStackPredicate> {
 
     override fun parse(reader: StringReader) = ItemStackParser(reader, true).parsePredicate()
 
+    companion object {
+
+        private val EXAMPLES = listOf("minecraft:stone", "stone", "#minecraft:boats", "stone{foo=bar}")
+
+    }
+
 }
 
 fun interface ItemStackPredicate {

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/ClearCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/ClearCommand.kt
@@ -1,0 +1,85 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kryptonmc.krypton.command.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.Component.translatable
+import org.kryptonmc.api.command.PermissionLevel
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.arguments.entities.EntityArgument
+import org.kryptonmc.krypton.command.arguments.entities.EntityQuery
+import org.kryptonmc.krypton.command.arguments.entities.entityArgument
+import org.kryptonmc.krypton.command.arguments.itemstack.ItemStackPredicate
+import org.kryptonmc.krypton.command.arguments.itemstack.ItemStackPredicateArgument
+import org.kryptonmc.krypton.command.permission
+import org.kryptonmc.krypton.entity.player.KryptonPlayer
+import org.kryptonmc.krypton.item.EmptyItemStack
+import org.kryptonmc.krypton.packet.out.play.PacketOutWindowItems
+import org.kryptonmc.krypton.util.argument
+import org.kryptonmc.krypton.util.toComponent
+
+object ClearCommand : InternalCommand {
+
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        dispatcher.register(literal<Sender>("clear")
+            .permission("krypton.command.clear", PermissionLevel.LEVEL_2)
+            .executes {
+                if(it.source !is KryptonPlayer) return@executes 1
+                clear(listOf(it.source as KryptonPlayer), it.source)
+                1
+            }
+            .then(argument<Sender, EntityQuery>("targets", EntityArgument.players())
+                .executes {
+                    clear(it.entityArgument("targets").getPlayers(it.source), it.source)
+                    1
+                }
+                .then(argument<Sender, ItemStackPredicate>("item", ItemStackPredicateArgument())
+                    .executes {
+                        clear(it.entityArgument("targets").getPlayers(it.source), it.source, it.argument("item"))
+                        1
+                    })))
+    }
+
+    private fun clear(targets: List<KryptonPlayer>, sender: Sender, predicate: ItemStackPredicate = ItemStackPredicate { true }, maxCount: Int = -1) {
+        if(targets.size == 1) {
+            val target = targets[0]
+            for ((i, item) in target.inventory.withIndex()) {
+                if(predicate(item)) {
+                    target.inventory[i] = EmptyItemStack
+                }
+            }
+            target.session.sendPacket(PacketOutWindowItems(target.inventory.id, target.inventory.stateId, target.inventory.networkItems, target.inventory.mainHand))
+            sender.sendMessage(translatable("commands.clear.success.single", listOf(text("all"), target.name.toComponent())))
+        } else {
+            for (target in targets) {
+                for ((i, item) in target.inventory.withIndex()) {
+                    if(predicate(item)) {
+                        target.inventory[i] = EmptyItemStack
+                    }
+                }
+                target.session.sendPacket(PacketOutWindowItems(target.inventory.id, target.inventory.stateId, target.inventory.networkItems, target.inventory.mainHand))
+            }
+            sender.sendMessage(translatable("commands.clear.success.multiple", listOf(text("all"), targets.size.toString().toComponent())))
+        }
+    }
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/ClearCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/ClearCommand.kt
@@ -23,7 +23,6 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
 import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
 import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.Component.translatable
-import org.kryptonmc.api.command.PermissionLevel
 import org.kryptonmc.api.command.Sender
 import org.kryptonmc.krypton.command.InternalCommand
 import org.kryptonmc.krypton.command.arguments.entities.EntityArgument
@@ -43,7 +42,7 @@ object ClearCommand : InternalCommand {
 
     override fun register(dispatcher: CommandDispatcher<Sender>) {
         dispatcher.register(literal<Sender>("clear")
-            .permission("krypton.command.clear", PermissionLevel.LEVEL_2)
+            .permission("krypton.command.clear", 2)
             .executes {
                 if(it.source !is KryptonPlayer) return@executes 1
                 clear(listOf(it.source as KryptonPlayer), it.source)

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/ClearCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/ClearCommand.kt
@@ -61,6 +61,7 @@ object ClearCommand : InternalCommand {
                     })))
     }
 
+    //-1 means that everything should be cleared (there is no limit)
     private fun clear(targets: List<KryptonPlayer>, sender: Sender, predicate: ItemStackPredicate = ItemStackPredicate { true }, maxCount: Int = -1) {
         val amount = if(maxCount == -1) "all" else maxCount.toString()
         if(targets.size == 1) {

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/GiveCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/GiveCommand.kt
@@ -1,12 +1,33 @@
+/*
+ * This file is part of the Krypton project, licensed under the GNU General Public License v3.0
+ *
+ * Copyright (C) 2021 KryptonMC and the contributors of the Krypton project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.kryptonmc.krypton.command.commands
 
 import com.mojang.brigadier.CommandDispatcher
 import com.mojang.brigadier.arguments.IntegerArgumentType
 import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
 import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
+import net.kyori.adventure.key.Key.key
+import net.kyori.adventure.sound.Sound
+import net.kyori.adventure.text.Component.text
+import org.kryptonmc.api.command.PermissionLevel
 import org.kryptonmc.api.command.Sender
-import org.kryptonmc.api.item.ItemStack
-import org.kryptonmc.api.item.ItemType
+import org.kryptonmc.krypton.KryptonServer
 import org.kryptonmc.krypton.command.InternalCommand
 import org.kryptonmc.krypton.command.arguments.entities.EntityArgument
 import org.kryptonmc.krypton.command.arguments.entities.EntityQuery
@@ -14,6 +35,7 @@ import org.kryptonmc.krypton.command.arguments.entities.entityArgument
 import org.kryptonmc.krypton.command.arguments.itemstack.ItemStackArgument
 import org.kryptonmc.krypton.command.arguments.itemstack.ItemStackArgumentType
 import org.kryptonmc.krypton.command.arguments.itemstack.itemStackArgument
+import org.kryptonmc.krypton.command.permission
 import org.kryptonmc.krypton.entity.player.KryptonPlayer
 import org.kryptonmc.krypton.packet.out.play.PacketOutWindowItems
 import org.kryptonmc.krypton.util.argument
@@ -22,12 +44,13 @@ object GiveCommand : InternalCommand {
 
     override fun register(dispatcher: CommandDispatcher<Sender>) {
         dispatcher.register(literal<Sender>("give")
+            .permission("krypton.command.give", PermissionLevel.LEVEL_2)
             .then(argument<Sender, EntityQuery>("targets", EntityArgument.players())
                 .then(argument<Sender, ItemStackArgument>("item", ItemStackArgumentType())
                     .executes {
                         val targets = it.entityArgument("targets").getPlayers(it.source)
                         val item = it.itemStackArgument("item")
-                        give(targets, item.item)
+                        give(targets, item, 1, it.source.server as KryptonServer)
                         1
                     }
                     .then(argument<Sender, Int>("count", IntegerArgumentType.integer(1))
@@ -35,15 +58,16 @@ object GiveCommand : InternalCommand {
                             val targets = it.entityArgument("targets").getPlayers(it.source)
                             val item = it.itemStackArgument("item")
                             val count = it.argument<Int>("count")
-                            give(targets, item.item, count)
+                            give(targets, item, count, it.source.server as KryptonServer)
                             1
                         }))))
     }
 
-    fun give(targets: List<KryptonPlayer>, item: ItemType, count: Int = 1) {
+    private fun give(targets: List<KryptonPlayer>, item: ItemStackArgument, count: Int = 1, server: KryptonServer) {
         for (target in targets) {
-            val itemStack = ItemStack.of(item, count)
-            target.inventory += itemStack
+            val items = item.createItemStacks(count, server)
+            items.forEach { target.inventory += it }
+            target.playSound(Sound.sound(key("entity.item.pickup"), Sound.Source.PLAYER, 0.2f, 2f))
             target.session.sendPacket(PacketOutWindowItems(target.inventory.id, target.inventory.stateId, target.inventory.networkItems, target.inventory.mainHand))
         }
     }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/GiveCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/GiveCommand.kt
@@ -25,7 +25,6 @@ import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
 import net.kyori.adventure.key.Key.key
 import net.kyori.adventure.sound.Sound
 import net.kyori.adventure.text.Component.text
-import org.kryptonmc.api.command.PermissionLevel
 import org.kryptonmc.api.command.Sender
 import org.kryptonmc.krypton.KryptonServer
 import org.kryptonmc.krypton.command.InternalCommand
@@ -44,7 +43,7 @@ object GiveCommand : InternalCommand {
 
     override fun register(dispatcher: CommandDispatcher<Sender>) {
         dispatcher.register(literal<Sender>("give")
-            .permission("krypton.command.give", PermissionLevel.LEVEL_2)
+            .permission("krypton.command.give", 2)
             .then(argument<Sender, EntityQuery>("targets", EntityArgument.players())
                 .then(argument<Sender, ItemStackArgument>("item", ItemStackArgumentType())
                     .executes {

--- a/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/GiveCommand.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/command/commands/GiveCommand.kt
@@ -1,0 +1,50 @@
+package org.kryptonmc.krypton.command.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.arguments.IntegerArgumentType
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
+import org.kryptonmc.api.command.Sender
+import org.kryptonmc.api.item.ItemStack
+import org.kryptonmc.api.item.ItemType
+import org.kryptonmc.krypton.command.InternalCommand
+import org.kryptonmc.krypton.command.arguments.entities.EntityArgument
+import org.kryptonmc.krypton.command.arguments.entities.EntityQuery
+import org.kryptonmc.krypton.command.arguments.entities.entityArgument
+import org.kryptonmc.krypton.command.arguments.itemstack.ItemStackArgument
+import org.kryptonmc.krypton.command.arguments.itemstack.ItemStackArgumentType
+import org.kryptonmc.krypton.command.arguments.itemstack.itemStackArgument
+import org.kryptonmc.krypton.entity.player.KryptonPlayer
+import org.kryptonmc.krypton.packet.out.play.PacketOutWindowItems
+import org.kryptonmc.krypton.util.argument
+
+object GiveCommand : InternalCommand {
+
+    override fun register(dispatcher: CommandDispatcher<Sender>) {
+        dispatcher.register(literal<Sender>("give")
+            .then(argument<Sender, EntityQuery>("targets", EntityArgument.players())
+                .then(argument<Sender, ItemStackArgument>("item", ItemStackArgumentType())
+                    .executes {
+                        val targets = it.entityArgument("targets").getPlayers(it.source)
+                        val item = it.itemStackArgument("item")
+                        give(targets, item.item)
+                        1
+                    }
+                    .then(argument<Sender, Int>("count", IntegerArgumentType.integer(1))
+                        .executes {
+                            val targets = it.entityArgument("targets").getPlayers(it.source)
+                            val item = it.itemStackArgument("item")
+                            val count = it.argument<Int>("count")
+                            give(targets, item.item, count)
+                            1
+                        }))))
+    }
+
+    fun give(targets: List<KryptonPlayer>, item: ItemType, count: Int = 1) {
+        for (target in targets) {
+            val itemStack = ItemStack.of(item, count)
+            target.inventory += itemStack
+            target.session.sendPacket(PacketOutWindowItems(target.inventory.id, target.inventory.stateId, target.inventory.networkItems, target.inventory.mainHand))
+        }
+    }
+}

--- a/server/src/main/kotlin/org/kryptonmc/krypton/inventory/KryptonInventory.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/inventory/KryptonInventory.kt
@@ -71,7 +71,7 @@ abstract class KryptonInventory(
                     if(item.amount == 0) return
                 }
             } else if (element == EmptyItemStack) {
-                items[index] = item
+                items[index + 9] = item
                 return
             }
         }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/inventory/KryptonInventory.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/inventory/KryptonInventory.kt
@@ -25,6 +25,7 @@ import org.kryptonmc.api.item.ItemStack
 import org.kryptonmc.krypton.item.EmptyItemStack
 import org.kryptonmc.krypton.item.KryptonItemStack
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.math.max
 
 abstract class KryptonInventory(
     val id: Int,
@@ -58,9 +59,21 @@ abstract class KryptonInventory(
     override fun plusAssign(item: ItemStack) {
         if (item !is KryptonItemStack) return
         items.forEachIndexed { index, element ->
-            if (element !== EmptyItemStack) return@forEachIndexed
-            items[index] = item
-            return
+            if (element.type == item.type) {
+                val initialAmount = element.amount
+                val maxAmount = element.type.maximumAmount
+                if ((initialAmount + item.amount) <= maxAmount) {
+                    element.amount = initialAmount + item.amount
+                    return
+                } else if (element.amount != maxAmount) {
+                    element.amount = maxAmount
+                    item.amount = maxAmount - item.amount
+                    if(item.amount == 0) return
+                }
+            } else if (element == EmptyItemStack) {
+                items[index] = item
+                return
+            }
         }
     }
 

--- a/server/src/main/kotlin/org/kryptonmc/krypton/inventory/KryptonPlayerInventory.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/inventory/KryptonPlayerInventory.kt
@@ -105,14 +105,7 @@ class KryptonPlayerInventory(override val owner: KryptonPlayer) : KryptonInvento
     }
 
     override val networkItems: List<KryptonItemStack>
-        get() {
-            val list = mutableListOf<KryptonItemStack>()
-            crafting.forEach { list.add(it) }
-            armor.forEach { list.add(it) }
-            items.forEach { list.add(it) }
-            list.add(offHand)
-            return list
-        }
+        get() = (crafting + armor + items + offHand).toList()
 
     companion object {
 

--- a/server/src/main/kotlin/org/kryptonmc/krypton/server/PlayerManager.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/server/PlayerManager.kt
@@ -252,15 +252,15 @@ class PlayerManager(private val server: KryptonServer) : ForwardingAudience {
 
     fun addToOperators(profile: KryptonGameProfile) {
         ops += OperatorEntry(profile, server.config.server.opPermissionLevel, true)
-        if (server.player(profile.uuid) != null) server.commandManager.sendCommands(server.player(profile.uuid)!!)
+        if (server.player(profile.uuid) != null) sendCommands(server.player(profile.uuid)!!)
     }
 
     fun removeFromOperators(profile: KryptonGameProfile) {
         ops -= profile
-        if (server.player(profile.uuid) != null) server.commandManager.sendCommands(server.player(profile.uuid)!!)
+        if (server.player(profile.uuid) != null) sendCommands(server.player(profile.uuid)!!)
     }
 
-    private fun sendCommands(player: KryptonPlayer) {
+    internal fun sendCommands(player: KryptonPlayer) {
         val permissionLevel = player.server.getPermissionLevel(player.profile)
         sendCommands(player, permissionLevel)
     }


### PR DESCRIPTION
As the title says this PR adds the ItemStackArgument and the ItemStackPredicateArgument and the two commands around them: **Clear**, **Give**. Also this PR fixes some bugs from the ServerConfigLists

All features:
- Fix ServerConfigLists
- Add duplicate check to UserCache 
- Add ItemStackArgument
- Add ItemStackPredicateArgument
- Add Clear Command
- Add Give Command
- Improve the plusAssign method in KryptonInventory

Problems left:
- Mostly the wrong item ids are sent to the player