### PR TITLE
Check for Max Health + Gamemode

### DIFF
--- a/api/src/main/kotlin/org/kryptonmc/api/entity/LivingEntity.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/entity/LivingEntity.kt
@@ -27,7 +27,7 @@ public interface LivingEntity : Entity, AttributeHolder {
      * The maximum health of this entity.
      */
     @get:JvmName("maxHealth")
-    public var maxHealth: Float
+    public val maxHealth: Float
 
     /**
      * The amount of absorption this living entity has.

--- a/api/src/main/kotlin/org/kryptonmc/api/entity/LivingEntity.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/entity/LivingEntity.kt
@@ -24,6 +24,12 @@ public interface LivingEntity : Entity, AttributeHolder {
     public var health: Float
 
     /**
+     * The maximum health of this entity.
+     */
+    @get:JvmName("maxHealth")
+    public var maxHealth: Float
+
+    /**
      * The amount of absorption this living entity has.
      */
     @get:JvmName("absorption")

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/KryptonLivingEntity.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/KryptonLivingEntity.kt
@@ -52,7 +52,7 @@ abstract class KryptonLivingEntity(
     attributeSupplier: AttributeSupplier
 ) : KryptonEntity(world, type), LivingEntity {
 
-    val maxHealth: Float
+    override val maxHealth: Float
         get() = attributes.value(AttributeTypes.MAX_HEALTH).toFloat()
     override var absorption = 0F
     final override val isAlive: Boolean

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/KryptonLivingEntity.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/KryptonLivingEntity.kt
@@ -52,7 +52,7 @@ abstract class KryptonLivingEntity(
     attributeSupplier: AttributeSupplier
 ) : KryptonEntity(world, type), LivingEntity {
 
-    private val maxHealth: Float
+    val maxHealth: Float
         get() = attributes.value(AttributeTypes.MAX_HEALTH).toFloat()
     override var absorption = 0F
     final override val isAlive: Boolean

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/player/KryptonPlayer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/player/KryptonPlayer.kt
@@ -508,16 +508,22 @@ class KryptonPlayer(
         // a player healing infinitely.
         if (foodTickTimer == 80) {
             if (foodLevel >= 18) {
-                health++ // Regenerate health
-                // Once a half-heart has been added, increase the exhaustion by 3,
-                // or if that operation were to exceed the threshold, instead, set it to the
-                // threshold value of 4.
-                foodExhaustionLevel = min(foodExhaustionLevel + 3f, 4f)
-                // Force the saturation level to deplete by 3.
-                // So as health comes up, the food "buffer" comes down,
-                // eventually causing the food level to decrease, when saturation
-                // reaches zero.
-                foodSaturationLevel -= 3
+                // Avoid exceeding max health
+                if (maxHealth >= health + 1) {
+                    // Regenerate health
+                    health++
+                    // Once a half-heart has been added, increase the exhaustion by 3,
+                    // or if that operation were to exceed the threshold, instead, set it to the
+                    // threshold value of 4.
+                    foodExhaustionLevel = min(foodExhaustionLevel + 3f, 4f)
+                    // Force the saturation level to deplete by 3.
+                    // So as health comes up, the food "buffer" comes down,
+                    // eventually causing the food level to decrease, when saturation
+                    // reaches zero.
+                    foodSaturationLevel -= 3
+                } else {
+                    health = maxHealth
+                }
             }
             foodTickTimer = 0 // reset tick timer
         }

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/player/KryptonPlayer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/player/KryptonPlayer.kt
@@ -434,7 +434,7 @@ class KryptonPlayer(
 
     private fun hungerMechanic() {
         // TODO: More actions for exhaustion, add constants?
-        if (!(gameMode == GameModes.SURVIVAL || gameMode == GameModes.ADVENTURE)) return
+        if (gameMode != GameModes.SURVIVAL && gameMode != GameModes.ADVENTURE) return
         foodTickTimer++
 
         // Sources:

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/player/KryptonPlayer.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/player/KryptonPlayer.kt
@@ -434,6 +434,7 @@ class KryptonPlayer(
 
     private fun hungerMechanic() {
         // TODO: More actions for exhaustion, add constants?
+        if (!(gameMode == GameModes.SURVIVAL || gameMode == GameModes.ADVENTURE)) return
         foodTickTimer++
 
         // Sources:


### PR DESCRIPTION
Check if a health regeneration won't exceed the max health of a player. If so, update the player's health, else, set the player's health to its max health. Additionally disable hunger mechanic if not in survival or adventure gamemodes.