### PR TITLE
Weather

### DIFF
--- a/api/src/main/kotlin/org/kryptonmc/api/entity/player/Player.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/entity/player/Player.kt
@@ -25,6 +25,7 @@ import org.kryptonmc.api.world.World
 import org.kryptonmc.api.world.dimension.DimensionType
 import org.kryptonmc.api.scoreboard.Scoreboard
 import org.kryptonmc.api.world.GameMode
+import org.kryptonmc.api.world.weather.WeatherContainer
 import org.spongepowered.math.vector.Vector3d
 import java.net.InetSocketAddress
 import java.time.Instant
@@ -34,7 +35,7 @@ import java.util.Locale
  * A player that is connected to the server and playing the game.
  */
 @Suppress("INAPPLICABLE_JVM_NAME")
-public interface Player : LivingEntity, Equipable, InventoryHolder, PluginMessageRecipient {
+public interface Player : LivingEntity, Equipable, InventoryHolder, PluginMessageRecipient, WeatherContainer {
 
     /**
      * The address that the player is currently connected from.

--- a/api/src/main/kotlin/org/kryptonmc/api/event/world/ChangeWeatherEvent.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/event/world/ChangeWeatherEvent.kt
@@ -1,0 +1,99 @@
+package org.kryptonmc.api.event.world
+
+import org.kryptonmc.api.event.ResultedEvent
+import org.kryptonmc.api.world.weather.Weather
+import org.kryptonmc.api.world.weather.WeatherContainer
+
+/**
+ * Called when the weather changes for the given [container].
+ *
+ * The [container] will usually only either be a world or a player. If you wish
+ * to perform different actions depending on which one of those it is, you can
+ * cast it.
+ *
+ * @param container the container that the weather changed for
+ * @param oldWeather the old weather
+ * @param newWeather the new weather
+ * @param cause the cause of the weather change
+ */
+public class ChangeWeatherEvent(
+    public val container: WeatherContainer,
+    public val oldWeather: Weather,
+    public val newWeather: Weather,
+    public val cause: Cause
+) : ResultedEvent<WeatherChangeResult> {
+
+    override var result: WeatherChangeResult = WeatherChangeResult.allowed()
+
+    /**
+     * The cause of a weather change.
+     */
+    public enum class Cause {
+
+        /**
+         * The server has loaded weather data and determined the current
+         * weather.
+         */
+        LOAD,
+
+        /**
+         * A request was made to change the weather.
+         */
+        API,
+
+        /**
+         * The weather controller changed the weather from a queued request.
+         */
+        CONTROLLER,
+
+        /**
+         * The weather was naturally changed by randomness.
+         */
+        NATURAL
+    }
+}
+
+/**
+ * The result of a [ChangeWeatherEvent].
+ *
+ * @param weather the replacement weather
+ */
+@JvmRecord
+public data class WeatherChangeResult(
+    override val isAllowed: Boolean,
+    public val weather: Weather?
+) : ResultedEvent.Result {
+
+    public companion object {
+
+        private val ALLOWED = WeatherChangeResult(true, null)
+        private val DENIED = WeatherChangeResult(false, null)
+
+        /**
+         * Gets the result that allows the event to continue as normal.
+         *
+         * @return the allowed result
+         */
+        @JvmStatic
+        public fun allowed(): WeatherChangeResult = ALLOWED
+
+        /**
+         * Creates a new result that allows the event to continue, but silently
+         * replaces the new weather with the given [weather].
+         *
+         * @param weather the replacement weather
+         * @return a new allowed result
+         */
+        @JvmStatic
+        public fun allowed(weather: Weather): WeatherChangeResult = WeatherChangeResult(true, weather)
+
+        /**
+         * Gets the result that denies the event from continuing, meaning the
+         * weather change will not occur.
+         *
+         * @return the denied result
+         */
+        @JvmStatic
+        public fun denied(): WeatherChangeResult = DENIED
+    }
+}

--- a/api/src/main/kotlin/org/kryptonmc/api/world/World.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/world/World.kt
@@ -23,6 +23,7 @@ import org.kryptonmc.api.scoreboard.Scoreboard
 import org.kryptonmc.api.world.chunk.Chunk
 import org.kryptonmc.api.world.dimension.DimensionType
 import org.kryptonmc.api.world.rule.GameRuleHolder
+import org.kryptonmc.api.world.weather.WeatherContainer
 import org.spongepowered.math.vector.Vector2i
 import org.spongepowered.math.vector.Vector3d
 import org.spongepowered.math.vector.Vector3i
@@ -32,7 +33,7 @@ import java.nio.file.Path
  * Represents a loaded world.
  */
 @Suppress("INAPPLICABLE_JVM_NAME")
-public interface World : ForwardingAudience {
+public interface World : ForwardingAudience, WeatherContainer {
 
     /**
      * The server this world was loaded on.

--- a/api/src/main/kotlin/org/kryptonmc/api/world/weather/Weather.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/world/weather/Weather.kt
@@ -1,0 +1,163 @@
+package org.kryptonmc.api.world.weather
+
+import net.kyori.adventure.util.Buildable
+import org.jetbrains.annotations.ApiStatus
+import org.jetbrains.annotations.Contract
+import org.kryptonmc.api.Krypton
+import org.kryptonmc.api.util.provide
+import java.time.Duration
+
+/**
+ * Data for the current weather for something.
+ */
+@Suppress("INAPPLICABLE_JVM_NAME")
+public interface Weather : Buildable<Weather, Weather.Builder> {
+
+    /**
+     * The type of weather that is currently occurring.
+     */
+    @get:JvmName("type")
+    public val type: WeatherType
+
+    /**
+     * How long the weather will last from the time when it was applied.
+     *
+     * If null, this weather will never expire.
+     */
+    @get:JvmName("duration")
+    public val duration: Duration?
+
+    /**
+     * The strength of this weather.
+     */
+    @get:JvmName("strength")
+    public val strength: Float
+
+    /**
+     * A builder for building weather.
+     */
+    public interface Builder : Buildable.Builder<Weather> {
+
+        /**
+         * Sets the type of the weather to the given [type].
+         *
+         * @param type the weather type
+         * @return this builder
+         */
+        @Contract("_ -> this", mutates = "this")
+        public fun type(type: WeatherType): Builder
+
+        /**
+         * Sets the duration of the weather to the given [duration].
+         *
+         * @param duration the duration
+         * @return this builder
+         */
+        @Contract("_ -> this", mutates = "this")
+        public fun duration(duration: Duration?): Builder
+
+        /**
+         * Makes the weather last forever.
+         *
+         * @return this builder
+         */
+        @Contract("_ -> this", mutates = "this")
+        public fun eternal(): Builder = duration(null)
+
+        /**
+         * Sets the strength of the weather to the given [strength].
+         *
+         * Note: this will only be effective if the type is [WeatherType.RAIN]
+         * or [WeatherType.THUNDER]. Clear weather does not have a strength
+         * value.
+         *
+         * @param strength the strength
+         * @return this builder
+         */
+        @Contract("_ -> this", mutates = "this")
+        public fun strength(strength: Float): Builder
+    }
+
+    @ApiStatus.Internal
+    public interface Factory {
+
+        public fun of(type: WeatherType, duration: Duration?, strength: Float): Weather
+
+        public fun builder(type: WeatherType): Builder
+    }
+
+    public companion object {
+
+        private val FACTORY = Krypton.factoryProvider.provide<Factory>()
+
+        /**
+         * Creates new weather with the given values.
+         *
+         * @param type the type of the weather
+         * @param duration how long the weather will last after it is applied
+         * @param strength the strength of the weather
+         * @return new weather
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun of(type: WeatherType, duration: Duration?, strength: Float = 0F): Weather = FACTORY.of(type, duration, strength)
+
+        /**
+         * Creates a new weather builder for building weather.
+         *
+         * @param type the type of weather
+         * @return a new weather builder
+         */
+        public fun builder(type: WeatherType): Builder = FACTORY.builder(type)
+
+        /**
+         * Creates new clear weather, optionally with the given [duration].
+         *
+         * @param duration how long the weather will last, null for all
+         * eternity
+         * @return new clear weather
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun clear(duration: Duration? = null): Weather = of(WeatherType.CLEAR, duration, 0F)
+
+        /**
+         * Creates new rain with the given values.
+         *
+         * @param duration how long the rain will last, null for all eternity
+         * @param strength the strength of the rain
+         * @return new rain
+         */
+        @JvmStatic
+        public fun rain(duration: Duration?, strength: Float): Weather = of(WeatherType.RAIN, duration, strength)
+
+        /**
+         * Creates new infinitely lasting rain with the given [strength].
+         *
+         * @param strength the strength of the rain
+         * @return new infinitely lasting rain
+         */
+        @JvmStatic
+        public fun rain(strength: Float): Weather = rain(null, strength)
+
+        /**
+         * Creates new thunder with the given values.
+         *
+         * @param duration how long the thunder will last, null for all
+         * eternity
+         * @param strength the strength of the thunder
+         * @return new thunder
+         */
+        @JvmStatic
+        public fun thunder(duration: Duration?, strength: Float): Weather = of(WeatherType.THUNDER, duration, strength)
+
+        /**
+         * Creates new infinitely lasting thunder with the given [strength].
+         *
+         * @param strength the strength of the thunder
+         * @return new thunder
+         */
+        @JvmStatic
+        public fun thunder(strength: Float): Weather = thunder(null, strength)
+    }
+}

--- a/api/src/main/kotlin/org/kryptonmc/api/world/weather/WeatherContainer.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/world/weather/WeatherContainer.kt
@@ -1,0 +1,14 @@
+package org.kryptonmc.api.world.weather
+
+/**
+ * Something that can contain weather.
+ */
+@Suppress("INAPPLICABLE_JVM_NAME")
+public interface WeatherContainer {
+
+    /**
+     * The weather controller for this container.
+     */
+    @get:JvmName("controller")
+    public val weatherController: WeatherController
+}

--- a/api/src/main/kotlin/org/kryptonmc/api/world/weather/WeatherController.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/world/weather/WeatherController.kt
@@ -1,0 +1,57 @@
+package org.kryptonmc.api.world.weather
+
+import java.time.Instant
+
+/**
+ * A controller for weather for something that can have weather.
+ */
+@Suppress("INAPPLICABLE_JVM_NAME")
+public interface WeatherController {
+
+    /**
+     * The current weather that is occurring.
+     */
+    @get:JvmName("currentWeather")
+    public val currentWeather: Weather
+
+    /**
+     * The time when the current weather was first started.
+     */
+    @get:JvmName("startTime")
+    public val startTime: Instant
+
+    /**
+     * The time remaining, in milliseconds, until the current weather will no
+     * longer be in effect.
+     */
+    @get:JvmName("remainingTime")
+    public val remainingTime: Long
+
+    /**
+     * Starts the given [weather], overriding the current weather.
+     *
+     * This will take effect immediately on invocation, and the weather will
+     * be changed. If you want to have the weather only take effect after the
+     * current weather is finished, use [queue].
+     *
+     * @param weather the weather to start
+     */
+    public fun start(weather: Weather)
+
+    /**
+     * Queues the given [weather] up, ready to take effect.
+     *
+     * All implementations of this should use a FIFO queue, to ensure that all
+     * weather is queued fairly, and applied in order of the queueing. However,
+     * this is not a strict requirement, and FIFO behaviour should not be
+     * depended on.
+     *
+     * @param weather the weather to queue
+     */
+    public fun queue(weather: Weather)
+
+    /**
+     * Immediately clears the current weather.
+     */
+    public fun clear()
+}

--- a/api/src/main/kotlin/org/kryptonmc/api/world/weather/WeatherType.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/world/weather/WeatherType.kt
@@ -1,0 +1,11 @@
+package org.kryptonmc.api.world.weather
+
+/**
+ * A type of weather.
+ */
+public enum class WeatherType {
+
+    CLEAR,
+    RAIN,
+    THUNDER
+}


### PR DESCRIPTION
### Introduction

This is my current design of the weather API that I want to go in to Krypton. It's a bit more complex than what I have seen in other APIs, so here's a list of some of its features:

* Starting and stopping weather immediately
* Queuing weather up for later application
* Scheduling of weather starting and stopping
* Proper per-world and per-player weather, and you can even apply the API to other things that may want controlling

The current design has `Weather`, which is simply a type that holds data about the weather, though this type is immutable, and does not hold any data that could tie it to a specific controller, so it can be easily reused.
Then, the heart of the design is the `WeatherController`, which can be used to start and stop weather, queue weather, clear weather, and also schedule weather starting and stopping (TODO).
There is also a container that holds a controller, mostly existing to avoid having to create two weather events, but it also allows users to create their own things that may have weather.

Questions that still remain unanswered:
* Should we use a scheduler for weather at all?
* Is this too much for something like weather?
* Could this be abstracted and applied to other things in the API?