### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ helping to make this possible.
 - [The Velocity project](https://velocitypowered.com/), for providing the plugin loading and permission systems that the Krypton API contains derivatives of.
 - [Minestom](https://minestom.net), for their support, API, and amazing community of welcoming individuals that have helped this project since it's very beginning.
 - [The Minecraft Coalition](https://wiki.vg), for their hard work and effort documenting the protocol, allowing these projects to exist.
-- [The Minecraft Wiki](https://minecraft.gamepedia.com), for their amazing efforts documenting just about everything
+- [The Minecraft Wiki](https://minecraft.wiki), for their amazing efforts documenting just about everything
   there is to know about Minecraft, and making it available for everyone to use.
 - The project's dependencies, each and every one helping to make our lives as developers easier.
 

--- a/api/src/main/kotlin/org/kryptonmc/api/block/entity/banner/BannerPatternType.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/block/entity/banner/BannerPatternType.kt
@@ -31,7 +31,7 @@ public interface BannerPatternType : Keyed {
 
     /**
      * The shortened code identifying the banner pattern, as specified by
-     * https://minecraft.fandom.com/wiki/Banner#Block_data
+     * https://minecraft.wiki/w/Banner#Block_data
      */
     @get:JvmName("code")
     public val code: String

--- a/api/src/main/kotlin/org/kryptonmc/api/effect/particle/ParticleTypes.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/effect/particle/ParticleTypes.kt
@@ -25,7 +25,7 @@ import org.kryptonmc.internal.annotations.Catalogue
 /**
  * All of the built-in vanilla particle types.
  *
- * See [here](https://minecraft.fandom.com/wiki/Particles) for more information
+ * See [here](https://minecraft.wiki/w/Particles) for more information
  * on all of these types.
  */
 @Catalogue(ParticleType::class)

--- a/api/src/main/kotlin/org/kryptonmc/api/entity/Entity.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/entity/Entity.kt
@@ -219,7 +219,7 @@ public interface Entity : Sender, HoverEventSource<HoverEvent.ShowEntity>, Sound
      * The amount of ticks this entity has been freezing for.
      *
      * Whilst this is available for all entities, it will only affect entities
-     * that are not in the ["freeze_immune_entity_types" entity type tag][https://minecraft.fandom.com/wiki/Tag#Entity_types].
+     * that are not in the ["freeze_immune_entity_types" entity type tag][https://minecraft.wiki/w/Tag#Entity_types].
      *
      * This value will increase by 1 for every tick this entity is in powder
      * snow, to a maximum of 300, and decrease by 2 for every tick this entity

--- a/api/src/main/kotlin/org/kryptonmc/api/state/Properties.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/state/Properties.kt
@@ -46,7 +46,7 @@ import org.kryptonmc.internal.annotations.Catalogue
 /**
  * All built-in block state properties.
  *
- * See [here](https://minecraft.fandom.com/wiki/Java_Edition_data_values#Block_states)
+ * See [here](https://minecraft.wiki/w/Java_Edition_data_values#Block_states)
  * for information on what types of blocks each property is applicable to.
  */
 @Catalogue(Property::class)
@@ -77,11 +77,11 @@ public object Properties {
      * generic property for certain types of plants. This has a range of 0-3.
      *
      * This is applicable to:
-     * - [Beetroots][Blocks.BEETROOTS] - see [here](https://minecraft.fandom.com/wiki/Block_states#Beetroots)
-     * - [Frosted Ice][Blocks.FROSTED_ICE] - see [here](https://minecraft.fandom.com/wiki/Block_states#Frosted_Ice)
-     * - [Nether Wart][Blocks.NETHER_WART] - see [here](https://minecraft.fandom.com/wiki/Block_states#Nether_Wart)
+     * - [Beetroots][Blocks.BEETROOTS] - see [here](https://minecraft.wiki/w/Block_states#Beetroots)
+     * - [Frosted Ice][Blocks.FROSTED_ICE] - see [here](https://minecraft.wiki/w/Block_states#Frosted_Ice)
+     * - [Nether Wart][Blocks.NETHER_WART] - see [here](https://minecraft.wiki/w/Block_states#Nether_Wart)
      * - [Sweet Berry Bush][Blocks.SWEET_BERRY_BUSH] - see
-     * [here](https://minecraft.fandom.com/wiki/Block_states#Sweet_Berry_Bush)
+     * [here](https://minecraft.wiki/w/Block_states#Sweet_Berry_Bush)
      */
     @JvmField
     public val AGE_3: Property<Int> = factory().forInt("AGE_3")
@@ -91,7 +91,7 @@ public object Properties {
      * generic property for certain types of plants. This has a range of 0-4.
      *
      * This is applicable to:
-     * - [Mangrove Propagules][Blocks.MANGROVE_PROPAGULE] - see [here](https://minecraft.fandom.com/wiki/Sapling#Block_states)
+     * - [Mangrove Propagules][Blocks.MANGROVE_PROPAGULE] - see [here](https://minecraft.wiki/w/Sapling#Block_states)
      */
     @JvmField
     public val AGE_4: Property<Int> = factory().forInt("AGE_4")
@@ -101,7 +101,7 @@ public object Properties {
      * generic property for certain types of plants. This has a range of 0-5.
      *
      * This is applicable to:
-     * - [Chorus flower][Blocks.CHORUS_FLOWER] - see [here](https://minecraft.fandom.com/wiki/Block_states#Chorus_Flower)
+     * - [Chorus flower][Blocks.CHORUS_FLOWER] - see [here](https://minecraft.wiki/w/Block_states#Chorus_Flower)
      */
     @JvmField
     public val AGE_5: Property<Int> = factory().forInt("AGE_5")
@@ -111,8 +111,8 @@ public object Properties {
      * generic property for certain types of plants. This has a range of 0-7.
      *
      * This is applicable to:
-     * - [Melon Stem][Blocks.MELON_STEM] - see [here](https://minecraft.fandom.com/wiki/Block_states#Melon_Stem)
-     * - [Pumpkin Stem][Blocks.PUMPKIN_STEM] - see [here](https://minecraft.fandom.com/wiki/Block_states#Pumpkin_Stem)
+     * - [Melon Stem][Blocks.MELON_STEM] - see [here](https://minecraft.wiki/w/Block_states#Melon_Stem)
+     * - [Pumpkin Stem][Blocks.PUMPKIN_STEM] - see [here](https://minecraft.wiki/w/Block_states#Pumpkin_Stem)
      */
     @JvmField
     public val AGE_7: Property<Int> = factory().forInt("AGE_7")
@@ -122,9 +122,9 @@ public object Properties {
      * generic property for certain types of plants. This has a range of 0, 5.
      *
      * This is applicable to:
-     * - [Cactus][Blocks.CACTUS] - see [here](https://minecraft.fandom.com/wiki/Block_states#Cactus)
-     * - [Fire][Blocks.FIRE] - see [here](https://minecraft.fandom.com/wiki/Block_states#Fire)
-     * - [Sugar Cane][Blocks.SUGAR_CANE] - see [here](https://minecraft.fandom.com/wiki/Block_states#Sugar_Cane)
+     * - [Cactus][Blocks.CACTUS] - see [here](https://minecraft.wiki/w/Block_states#Cactus)
+     * - [Fire][Blocks.FIRE] - see [here](https://minecraft.wiki/w/Block_states#Fire)
+     * - [Sugar Cane][Blocks.SUGAR_CANE] - see [here](https://minecraft.wiki/w/Block_states#Sugar_Cane)
      */
     @JvmField
     public val AGE_15: Property<Int> = factory().forInt("AGE_15")
@@ -134,7 +134,7 @@ public object Properties {
      * generic property for certain types of plants. This has a range of 0, 5.
      *
      * This is applicable to:
-     * - [Kelp][Blocks.KELP] - see [here](https://minecraft.fandom.com/wiki/Block_states#Kelp)
+     * - [Kelp][Blocks.KELP] - see [here](https://minecraft.wiki/w/Block_states#Kelp)
      */
     @JvmField
     public val AGE_25: Property<Int> = factory().forInt("AGE_25")
@@ -168,9 +168,9 @@ public object Properties {
      * This is applicable to all types of logs, stripped logs, wood, stripped
      * wood, stems, stripped stems, hyphae, stripped hyphae, as well as the
      * following other blocks:
-     * - [Bone Block][Blocks.BONE_BLOCK] - see [here](https://minecraft.fandom.com/wiki/Block_states#Bone_Block)
-     * - [Chain][Blocks.CHAIN] - see [here](https://minecraft.fandom.com/wiki/Block_states#Chain)
-     * - [Hay Bale][Blocks.HAY_BLOCK] - see [here](https://minecraft.fandom.com/wiki/Block_states#Hay_Bale)
+     * - [Bone Block][Blocks.BONE_BLOCK] - see [here](https://minecraft.wiki/w/Block_states#Bone_Block)
+     * - [Chain][Blocks.CHAIN] - see [here](https://minecraft.wiki/w/Block_states#Chain)
+     * - [Hay Bale][Blocks.HAY_BLOCK] - see [here](https://minecraft.wiki/w/Block_states#Hay_Bale)
      * - [Basalt][Blocks.BASALT]
      * - [Polished Basalt][Blocks.POLISHED_BASALT]
      * - [Quartz Pillar][Blocks.QUARTZ_PILLAR]
@@ -472,7 +472,7 @@ public object Properties {
 
     /**
      * How close the [Turtle Egg][Blocks.TURTLE_EGG] this property is applied
-     * to is to hatching. See [here](https://minecraft.fandom.com/wiki/Block_states#Turtle_Egg)
+     * to is to hatching. See [here](https://minecraft.wiki/w/Block_states#Turtle_Egg)
      * for more information.
      */
     @JvmField

--- a/api/src/main/kotlin/org/kryptonmc/api/world/biome/AmbientMoodSettings.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/world/biome/AmbientMoodSettings.kt
@@ -49,7 +49,7 @@ public interface AmbientMoodSettings {
      * The cubic range of possible positions to play the sound.
      *
      * The player is at the centre of the cubic range, and the edge length is
-     * `2 * blockSearchExtent + 1` (source: [The Official Minecraft Wiki](https://minecraft.fandom.com/wiki/Biome/JSON_format))
+     * `2 * blockSearchExtent + 1` (source: [The Official Minecraft Wiki](https://minecraft.wiki/w/Biome/JSON_format))
      */
     @get:JvmName("blockSearchExtent")
     public val blockSearchExtent: Int

--- a/api/src/main/kotlin/org/kryptonmc/api/world/chunk/Chunk.kt
+++ b/api/src/main/kotlin/org/kryptonmc/api/world/chunk/Chunk.kt
@@ -60,7 +60,7 @@ public interface Chunk : BlockContainer, FluidContainer, BiomeContainer, EntityC
      * Also note that regional difficulty is capped when this value reaches
      * 3600000, meaning that none of the above will increase past that point.
      *
-     * See [here](https://minecraft.gamepedia.com/Chunk_format#NBT_structure)
+     * See [here](https://minecraft.wiki/w/Chunk_format#NBT_structure)
      * for more details.
      */
     public val inhabitedTime: Long

--- a/server/src/main/kotlin/org/kryptonmc/krypton/entity/system/PlayerHungerSystem.kt
+++ b/server/src/main/kotlin/org/kryptonmc/krypton/entity/system/PlayerHungerSystem.kt
@@ -29,7 +29,7 @@ import kotlin.math.sqrt
 class PlayerHungerSystem(private val player: KryptonPlayer) {
 
     // Sources for vanilla hunger system values:
-    //      -> Minecraft Wiki https://minecraft.fandom.com/wiki/Hunger
+    //      -> Minecraft Wiki https://minecraft.wiki/w/Hunger
     // 20 is the default vanilla food level
     var foodLevel: Int = 20
     private var tickTimer = 0
@@ -46,7 +46,7 @@ class PlayerHungerSystem(private val player: KryptonPlayer) {
         tickTimer++
 
         // Sources:
-        //      -> Minecraft Wiki https://minecraft.fandom.com/wiki/Hunger
+        //      -> Minecraft Wiki https://minecraft.wiki/w/Hunger
         //      -> 3 other implementations of this exact mechanic (lines up with wiki)
 
         // Food System
@@ -153,7 +153,7 @@ class PlayerHungerSystem(private val player: KryptonPlayer) {
     }
 
     fun updateMovementExhaustion(deltaX: Double, deltaY: Double, deltaZ: Double) {
-        // Source: https://minecraft.fandom.com/wiki/Hunger#Exhaustion_level_increase
+        // Source: https://minecraft.wiki/w/Hunger#Exhaustion_level_increase
         if (player.isSwimming) {
             val value = sqrt(deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ)
             if (value > 0) exhaustionLevel += SWIMMING_EXHAUSTION_MODIFIER * value.toFloat()


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.